### PR TITLE
[flink-tidb-connector] fix the exception caused by calling the `getFunction` method of TIDBCatalog

### DIFF
--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseCatalog.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseCatalog.java
@@ -277,7 +277,7 @@ public abstract class TiDBBaseCatalog extends AbstractCatalog {
   @Override
   public CatalogFunction getFunction(ObjectPath functionPath)
       throws FunctionNotExistException, CatalogException {
-    throw new UnsupportedOperationException();
+    throw new FunctionNotExistException(getName(), functionPath);
   }
 
   @Override


### PR DESCRIPTION

- The following exception occurrs when I use `tEnv.useCatalog("tidb")` to set the default catalog to `tidb`:

```java
Exception in thread "main" org.apache.flink.table.api.ValidationException: SQL validation failed. null
	at org.apache.flink.table.planner.calcite.FlinkPlannerImpl.org$apache$flink$table$planner$calcite$FlinkPlannerImpl$$validate(FlinkPlannerImpl.scala:152)
	at org.apache.flink.table.planner.calcite.FlinkPlannerImpl.validate(FlinkPlannerImpl.scala:111)
	at org.apache.flink.table.planner.operations.SqlToOperationConverter.convert(SqlToOperationConverter.java:193)
	at org.apache.flink.table.planner.delegation.ParserImpl.parse(ParserImpl.java:78)
	at org.apache.flink.table.api.internal.TableEnvironmentImpl.executeSql(TableEnvironmentImpl.java:659)
	at com.itiger.datapipeline.util.TiDBCatalogDemo.main(TiDBCatalogDemo.java:49)
Caused by: java.lang.UnsupportedOperationException
	at io.tidb.bigdata.flink.tidb.TiDBBaseCatalog.getFunction(TiDBBaseCatalog.java:280)
	at org.apache.flink.table.catalog.FunctionCatalog.resolvePreciseFunctionReference(FunctionCatalog.java:577)
	at org.apache.flink.table.catalog.FunctionCatalog.lambda$resolveAmbiguousFunctionReference$2(FunctionCatalog.java:623)
	at java.util.Optional.orElseGet(Optional.java:267)
	at org.apache.flink.table.catalog.FunctionCatalog.resolveAmbiguousFunctionReference(FunctionCatalog.java:623)
	at org.apache.flink.table.catalog.FunctionCatalog.lookupFunction(FunctionCatalog.java:369)
	at org.apache.flink.table.planner.catalog.FunctionCatalogOperatorTable.lookupOperatorOverloads(FunctionCatalogOperatorTable.java:98)
	at org.apache.calcite.sql.util.ChainedSqlOperatorTable.lookupOperatorOverloads(ChainedSqlOperatorTable.java:67)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.makeNullaryCall(SqlValidatorImpl.java:1710)
	at org.apache.calcite.sql.validate.SqlValidatorImpl$Expander.visit(SqlValidatorImpl.java:6011)
	at org.apache.calcite.sql.validate.SqlValidatorImpl$Expander.visit(SqlValidatorImpl.java:6000)
	at org.apache.calcite.sql.SqlIdentifier.accept(SqlIdentifier.java:320)
	at org.apache.calcite.sql.util.SqlShuttle$CallCopyingArgHandler.visitChild(SqlShuttle.java:134)
	at org.apache.calcite.sql.util.SqlShuttle$CallCopyingArgHandler.visitChild(SqlShuttle.java:101)
	at org.apache.calcite.sql.SqlOperator.acceptCall(SqlOperator.java:879)
	at org.apache.calcite.sql.validate.SqlValidatorImpl$Expander.visitScoped(SqlValidatorImpl.java:6033)
	at org.apache.calcite.sql.validate.SqlScopedShuttle.visit(SqlScopedShuttle.java:50)
	at org.apache.calcite.sql.validate.SqlScopedShuttle.visit(SqlScopedShuttle.java:33)
	at org.apache.calcite.sql.SqlCall.accept(SqlCall.java:139)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.expand(SqlValidatorImpl.java:5609)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateWhereClause(SqlValidatorImpl.java:4123)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateSelect(SqlValidatorImpl.java:3464)
	at org.apache.calcite.sql.validate.SelectNamespace.validateImpl(SelectNamespace.java:60)
	at org.apache.calcite.sql.validate.AbstractNamespace.validate(AbstractNamespace.java:84)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateNamespace(SqlValidatorImpl.java:1067)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateQuery(SqlValidatorImpl.java:1041)
	at org.apache.calcite.sql.SqlSelect.validate(SqlSelect.java:232)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateScopedExpression(SqlValidatorImpl.java:1016)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validate(SqlValidatorImpl.java:724)
	at org.apache.flink.table.planner.calcite.FlinkPlannerImpl.org$apache$flink$table$planner$calcite$FlinkPlannerImpl$$validate(FlinkPlannerImpl.scala:147)
	... 5 more
```

- The reason for this exception:

1. In Flink SQL validate stage, the `getFunction` method of the current catalog will be called for lookup functions.
2. Users can use the method `useCatalog(...)` in TableEnvironment to set up the current catalog of the `CatalogManager`.
3. By default, flink `CatalogManager` uses `GenericInMemoryCatalog` as the current default catalog, but when we use `tEnv.useCatalog("tidb")` to switch the current catalog to `tidbCatalog`, the `getFunction` method in TIDBCatalog will be called which will cause the above exception.
4. The `FunctionNotExistException` will be caught and ignored in `FunctionCatalog.resolvePreciseFunctionReference`.