### PR TITLE
fix error on new ci

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -12,6 +12,7 @@ def call(ghprbActualCommit, ghprbPullId, ghprbPullTitle, ghprbPullLink, ghprbPul
     if (m1) {
         TIDB_BRANCH = "${m1[0][1]}"
     }
+    m1 = null
     println "TIDB_BRANCH=${TIDB_BRANCH}"
 
     // parse pd branch
@@ -19,6 +20,7 @@ def call(ghprbActualCommit, ghprbPullId, ghprbPullTitle, ghprbPullLink, ghprbPul
     if (m2) {
         PD_BRANCH = "${m2[0][1]}"
     }
+    m2 = null
     println "PD_BRANCH=${PD_BRANCH}"
 
     // parse tikv branch
@@ -26,6 +28,7 @@ def call(ghprbActualCommit, ghprbPullId, ghprbPullTitle, ghprbPullLink, ghprbPul
     if (m3) {
         TIKV_BRANCH = "${m3[0][1]}"
     }
+    m3 = null
     println "TIKV_BRANCH=${TIKV_BRANCH}"
 
     // parse ticdc branch
@@ -33,6 +36,7 @@ def call(ghprbActualCommit, ghprbPullId, ghprbPullTitle, ghprbPullLink, ghprbPul
     if (m4) {
         TICDC_BRANCH = "${m4[0][1]}"
     }
+    m4 = null
     println "TICDC_BRANCH=${TICDC_BRANCH}"
 
     catchError {


### PR DESCRIPTION
fix a jenkins error on new ci jenkins: Caused: java.io.NotSerializableException: java.util.regex.Matcher