### PR TITLE
[flink-tidb-connector] support flink-1.13 (issue#76)

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 mvn clean compile -am -pl ticdc
 mvn clean compile -am -pl flink/flink-1.11
 mvn clean compile -am -pl flink/flink-1.12
+mvn clean compile -am -pl flink/flink-1.13
 mvn clean compile -am -pl mapreduce/mapreduce-base
 mvn clean compile -am -pl prestodb
 mvn clean compile -am -pl jdbc

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -11,5 +11,6 @@ mvn clean test -am -pl jdbc
 mvn clean test -am -pl ticdc
 mvn clean test -am -pl flink/flink-1.11
 mvn clean test -am -pl flink/flink-1.12
+mvn clean test -am -pl flink/flink-1.13
 mvn clean test -am -pl mapreduce/mapreduce-base
 mvn clean test -am -pl prestodb

--- a/flink/README.md
+++ b/flink/README.md
@@ -11,7 +11,7 @@
 
 ## Version
 
-`Flink-1.11` and `Flink-1.12` are supported.
+`Flink-1.11`, `Flink-1.12` and `Flink-1.13` are supported.
 
 ## Build
 

--- a/flink/flink-1.11/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
+++ b/flink/flink-1.11/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
@@ -231,8 +231,8 @@ public class FlinkTest {
     TableEnvironment tableEnvironment = getTableEnvironment();
     Map<String, String> properties = getDefaultProperties();
     properties.put("connector", "tidb");
-    properties.put(TiDBDynamicTableFactory.DATABASE_NAME.key(), "test");
-    properties.put(TiDBDynamicTableFactory.TABLE_NAME.key(), "test_timestamp");
+    properties.put(TiDBConfigOptions.DATABASE_NAME.key(), "test");
+    properties.put(TiDBConfigOptions.TABLE_NAME.key(), "test_timestamp");
     properties.put("timestamp-format.c1", "yyyy-MM-dd HH:mm:ss");
     properties.put("timestamp-format.c2", "yyyy-MM-dd HH:mm:ss");
     // create test database and table

--- a/flink/flink-1.12/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableFactory.java
+++ b/flink/flink-1.12/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableFactory.java
@@ -16,6 +16,9 @@
 
 package io.tidb.bigdata.flink.tidb;
 
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
+
 import io.tidb.bigdata.cdc.Key.Type;
 import io.tidb.bigdata.flink.format.cdc.CraftFormatFactory;
 import io.tidb.bigdata.flink.format.cdc.FormatOptions;

--- a/flink/flink-1.12/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableSource.java
+++ b/flink/flink-1.12/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableSource.java
@@ -16,8 +16,8 @@
 
 package io.tidb.bigdata.flink.tidb;
 
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.DATABASE_NAME;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.TABLE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
 
 import com.google.common.collect.ImmutableSet;
 import io.tidb.bigdata.tidb.ClientSession;

--- a/flink/flink-1.12/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
+++ b/flink/flink-1.12/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
@@ -252,8 +252,8 @@ public class FlinkTest {
     TableEnvironment tableEnvironment = getTableEnvironment();
     Map<String, String> properties = getDefaultProperties();
     properties.put("connector", "tidb");
-    properties.put(TiDBDynamicTableFactory.DATABASE_NAME.key(), "test");
-    properties.put(TiDBDynamicTableFactory.TABLE_NAME.key(), "test_timestamp");
+    properties.put(TiDBConfigOptions.DATABASE_NAME.key(), "test");
+    properties.put(TiDBConfigOptions.TABLE_NAME.key(), "test_timestamp");
     properties.put("timestamp-format.c1", "yyyy-MM-dd HH:mm:ss");
     properties.put("timestamp-format.c2", "yyyy-MM-dd HH:mm:ss");
     // create test database and table

--- a/flink/flink-1.13/pom.xml
+++ b/flink/flink-1.13/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.tidb</groupId>
+        <artifactId>flink-tidb-connector</artifactId>
+        <version>0.0.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-tidb-connector-1.13</artifactId>
+    <packaging>jar</packaging>
+    <name>Flink Connector 1.13</name>
+    <url>https://github.com/pingcap-incubator/TiBigData</url>
+
+    <properties>
+        <dep.flink.version>1.13.0</dep.flink.version>
+    </properties>
+
+    <dependencies>
+        <!-- flink base -->
+        <dependency>
+            <groupId>io.tidb</groupId>
+            <artifactId>flink-tidb-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${dep.jackson.version}</version>
+        </dependency>
+        <!-- apache commons -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${dep.apache.commons.version}</version>
+        </dependency>
+        <!-- flink -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <version>${dep.flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${dep.scala.binary.version}</artifactId>
+            <version>${dep.flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${dep.scala.binary.version}</artifactId>
+            <version>${dep.flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge_${dep.scala.binary.version}</artifactId>
+            <version>${dep.flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${dep.scala.binary.version}</artifactId>
+            <version>${dep.flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${dep.scala.binary.version}</artifactId>
+            <version>${dep.flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-jdbc_${dep.scala.binary.version}</artifactId>
+            <version>${dep.flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${dep.mysql.jdbc.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${dep.junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>shade.bigdata.com.google.common</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <finalName>${project.artifactId}-${project.version}</finalName>
+                            <transformers>
+                                <transformer
+                                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBCatalog.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBCatalog.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.flink.table.factories.Factory;
+
+public class TiDBCatalog extends TiDBBaseCatalog {
+
+  public TiDBCatalog(String name, String defaultDatabase, Map<String, String> properties) {
+    super(name, defaultDatabase, properties);
+  }
+
+  public TiDBCatalog(String name, Map<String, String> properties) {
+    super(name, properties);
+  }
+
+  public TiDBCatalog(Map<String, String> properties) {
+    super(properties);
+  }
+
+  @Override
+  public Optional<Factory> getFactory() {
+    return Optional.of(new TiDBDynamicTableFactory());
+  }
+
+}

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBCatalogFactory.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBCatalogFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.factories.CatalogFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+/**
+ * Factory for {@link TiDBCatalog}
+ */
+public class TiDBCatalogFactory implements CatalogFactory {
+
+  @Override
+  public String factoryIdentifier() {
+    return TiDBConfigOptions.IDENTIFIER;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    return ImmutableSet.of(
+        TiDBConfigOptions.DATABASE_URL,
+        TiDBConfigOptions.USERNAME
+    );
+  }
+
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    return ImmutableSet.of(
+        TiDBConfigOptions.PASSWORD,
+        TiDBConfigOptions.MAX_POOL_SIZE,
+        TiDBConfigOptions.MIN_IDLE_SIZE,
+        TiDBConfigOptions.WRITE_MODE,
+        TiDBConfigOptions.REPLICA_READ,
+        TiDBConfigOptions.FILTER_PUSH_DOWN
+    );
+  }
+
+  @Override
+  public Catalog createCatalog(Context context) {
+    final FactoryUtil.CatalogFactoryHelper helper =
+        FactoryUtil.createCatalogFactoryHelper(this, context);
+    helper.validate();
+    return new TiDBCatalog(context.getName(), context.getOptions());
+  }
+
+}

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableFactory.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb;
+
+import org.apache.flink.table.connector.source.DynamicTableSource;
+
+public class TiDBDynamicTableFactory extends TiDBBaseDynamicTableFactory {
+
+  @Override
+  public DynamicTableSource createDynamicTableSource(Context context) {
+    return new TiDBDynamicTableSource(
+        context.getCatalogTable().getSchema(),
+        context.getCatalogTable().toProperties(),
+        getLookupOptions(context));
+  }
+
+}

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableSource.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBDynamicTableSource.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb;
+
+
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
+
+import com.google.common.collect.ImmutableSet;
+import io.tidb.bigdata.tidb.ClientSession;
+import io.tidb.bigdata.tidb.Expressions;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.jdbc.internal.options.JdbcLookupOptions;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.InputFormatProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.expression.Expression;
+import org.tikv.common.expression.visitor.SupportedExpressionValidator;
+import org.tikv.common.meta.TiColumnInfo;
+import org.tikv.common.types.DataType;
+
+public class TiDBDynamicTableSource extends TiDBBaseDynamicTableSource implements
+    SupportsLimitPushDown,
+    SupportsProjectionPushDown,
+    SupportsFilterPushDown {
+
+  static final Logger LOG = LoggerFactory.getLogger(TiDBDynamicTableSource.class);
+
+  protected static final Set<String> COMPARISON_BINARY_FILTERS = ImmutableSet.of(
+      "greaterThan",
+      "greaterThanOrEqual",
+      "lessThan",
+      "lessThanOrEqual",
+      "equals",
+      "notEquals",
+      "like"
+  );
+
+  protected long limit = Long.MAX_VALUE;
+
+  protected int[][] projectedFields;
+
+  protected Expression expression;
+
+  protected Map<String, DataType> nameTypeMap;
+
+  public TiDBDynamicTableSource(TableSchema tableSchema, Map<String, String> properties,
+                                JdbcLookupOptions lookupOptions) {
+    super(tableSchema, properties, lookupOptions);
+  }
+
+  @Override
+  public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+    TypeInformation<RowData> typeInformation = runtimeProviderContext
+        .createTypeInformation(tableSchema.toRowDataType());
+    TiDBRowDataInputFormat tidbRowDataInputFormat = new TiDBRowDataInputFormat(properties,
+        tableSchema.getFieldNames(), tableSchema.getFieldDataTypes(), typeInformation);
+    tidbRowDataInputFormat.setLimit(limit);
+    if (projectedFields != null) {
+      tidbRowDataInputFormat.setProjectedFields(projectedFields);
+    }
+    if (expression != null) {
+      tidbRowDataInputFormat.setExpression(expression);
+    }
+    return InputFormatProvider.of(tidbRowDataInputFormat);
+  }
+
+  @Override
+  public DynamicTableSource copy() {
+    TiDBDynamicTableSource tableSource = new TiDBDynamicTableSource(tableSchema, properties,
+        lookupOptions);
+    tableSource.limit = this.limit;
+    tableSource.projectedFields = this.projectedFields;
+    tableSource.expression = this.expression;
+    return tableSource;
+  }
+
+  @Override
+  public void applyLimit(long limit) {
+    this.limit = limit;
+  }
+
+  @Override
+  public boolean supportsNestedProjection() {
+    return false;
+  }
+
+  @Override
+  public void applyProjection(int[][] projectedFields) {
+    this.projectedFields = projectedFields;
+  }
+
+  @Override
+  public Result applyFilters(List<ResolvedExpression> filters) {
+    LOG.debug("flink filters: " + filters);
+    if (config.isFilterPushDown()) {
+      this.expression = createExpression(filters);
+    }
+    LOG.debug("tidb expression: " + this.expression);
+    return Result.of(Collections.emptyList(), filters);
+  }
+
+  protected void queryNameType() {
+    String databaseName = getRequiredProperties(DATABASE_NAME.key());
+    String tableName = getRequiredProperties(TABLE_NAME.key());
+    try (ClientSession clientSession = ClientSession.createWithSingleConnection(config)) {
+      this.nameTypeMap = clientSession.getTableMust(databaseName, tableName).getColumns()
+          .stream().collect(Collectors.toMap(TiColumnInfo::getName, TiColumnInfo::getType));
+    } catch (Exception e) {
+      throw new IllegalStateException("can not get columns", e);
+    }
+  }
+
+  protected Expression createExpression(List<ResolvedExpression> filters) {
+    if (filters == null || filters.size() == 0) {
+      return null;
+    }
+    if (nameTypeMap == null) {
+      queryNameType();
+    }
+    return getExpression(filters);
+  }
+
+  protected Expression getExpression(List<ResolvedExpression> resolvedExpressions) {
+    return Expressions.and(resolvedExpressions.stream().map(this::getExpression)
+        .filter(exp -> exp != Expressions.alwaysTrue()));
+  }
+
+  protected Expression getExpression(ResolvedExpression resolvedExpression) {
+    if (resolvedExpression instanceof CallExpression) {
+      CallExpression callExpression = (CallExpression) resolvedExpression;
+      List<ResolvedExpression> resolvedChildren = callExpression.getResolvedChildren();
+      String functionName = callExpression.getFunctionName();
+      Expression left = null;
+      Expression right = null;
+      if (COMPARISON_BINARY_FILTERS.contains(functionName)) {
+        left = getExpression(resolvedChildren.get(0));
+        right = getExpression(resolvedChildren.get(1));
+        if (left == Expressions.alwaysTrue() || right == Expressions.alwaysTrue()) {
+          return Expressions.alwaysTrue();
+        }
+      }
+      switch (functionName) {
+        case "cast":
+          // we only need column name
+          return getExpression(resolvedChildren.get(0));
+        case "or":
+          // ignore always true expression
+          return Expressions.or(resolvedChildren.stream().map(this::getExpression)
+              .filter(exp -> exp != Expressions.alwaysTrue()));
+        case "not":
+          if (left == Expressions.alwaysTrue()) {
+            return Expressions.alwaysTrue();
+          }
+          return alwaysTrueIfNotSupported(Expressions.not(left));
+        case "greaterThan":
+          return alwaysTrueIfNotSupported(Expressions.greaterThan(left, right));
+        case "greaterThanOrEqual":
+          return alwaysTrueIfNotSupported(Expressions.greaterEqual(left, right));
+        case "lessThan":
+          return alwaysTrueIfNotSupported(Expressions.lessThan(left, right));
+        case "lessThanOrEqual":
+          return alwaysTrueIfNotSupported(Expressions.lessEqual(left, right));
+        case "equals":
+          return alwaysTrueIfNotSupported(Expressions.equal(left, right));
+        case "notEquals":
+          return alwaysTrueIfNotSupported(Expressions.notEqual(left, right));
+        case "like":
+          return alwaysTrueIfNotSupported(Expressions.like(left, right));
+        default:
+          return Expressions.alwaysTrue();
+      }
+    }
+    if (resolvedExpression instanceof FieldReferenceExpression) {
+      String name = ((FieldReferenceExpression) resolvedExpression).getName();
+      return Expressions.column(name, nameTypeMap.get(name));
+    }
+    if (resolvedExpression instanceof ValueLiteralExpression) {
+      ValueLiteralExpression valueLiteralExpression = (ValueLiteralExpression) resolvedExpression;
+      Object value = valueLiteralExpression
+          .getValueAs(valueLiteralExpression.getOutputDataType().getConversionClass())
+          .orElseThrow(() -> new IllegalStateException("can not get value"));
+      return Expressions.constant(value, null);
+    }
+    return Expressions.alwaysTrue();
+  }
+
+  protected Expression alwaysTrueIfNotSupported(Expression expression) {
+    return SupportedExpressionValidator.isSupportedExpression(expression, null)
+        ? expression : Expressions.alwaysTrue();
+  }
+
+}

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBRowDataInputFormat.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/TiDBRowDataInputFormat.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb;
+
+import java.util.Map;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+public class TiDBRowDataInputFormat extends TiDBBaseRowDataInputFormat {
+
+  public TiDBRowDataInputFormat(Map<String, String> properties,
+                                String[] fieldNames, DataType[] fieldTypes,
+                                TypeInformation<RowData> typeInformation) {
+    super(properties, fieldNames, fieldTypes, typeInformation);
+  }
+
+}

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/examples/TiDBCatalogDemo.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/tidb/examples/TiDBCatalogDemo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb.examples;
+
+import io.tidb.bigdata.flink.tidb.TiDBCatalog;
+import java.util.Map;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+
+public class TiDBCatalogDemo {
+
+  public static void main(String[] args) {
+    // properties
+    ParameterTool parameterTool = ParameterTool.fromArgs(args);
+    final Map<String, String> properties = parameterTool.toMap();
+    final String databaseName = parameterTool.getRequired("tidb.database.name");
+    final String tableName = parameterTool.getRequired("tidb.table.name");
+
+    // env
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner()
+        .inBatchMode().build();
+    TableEnvironment tableEnvironment = TableEnvironment.create(settings);
+
+    // register TiDBCatalog
+    TiDBCatalog catalog = new TiDBCatalog(properties);
+    catalog.open();
+    tableEnvironment.registerCatalog("tidb", catalog);
+
+    // query and print
+    String sql = String.format("SELECT * FROM `tidb`.`%s`.`%s` LIMIT 100", databaseName, tableName);
+    System.out.println("Flink SQL: " + sql);
+    TableResult tableResult = tableEnvironment.executeSql(sql);
+    System.out.println("TableSchema: \n" + tableResult.getTableSchema());
+    tableResult.print();
+  }
+
+}

--- a/flink/flink-1.13/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink/flink-1.13/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+io.tidb.bigdata.flink.tidb.TiDBDynamicTableFactory

--- a/flink/flink-1.13/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink/flink-1.13/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+io.tidb.bigdata.flink.tidb.TiDBCatalogFactory

--- a/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
+++ b/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
@@ -1,0 +1,357 @@
+package io.tidb.bigdata.flink.tidb;
+
+import static io.tidb.bigdata.tidb.ClientConfig.DATABASE_URL;
+import static io.tidb.bigdata.tidb.ClientConfig.MAX_POOL_SIZE;
+import static io.tidb.bigdata.tidb.ClientConfig.MIN_IDLE_SIZE;
+import static io.tidb.bigdata.tidb.ClientConfig.PASSWORD;
+import static io.tidb.bigdata.tidb.ClientConfig.TIDB_REPLICA_READ;
+import static io.tidb.bigdata.tidb.ClientConfig.TIDB_WRITE_MODE;
+import static io.tidb.bigdata.tidb.ClientConfig.USERNAME;
+import static java.lang.String.format;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FlinkTest {
+
+  public static final String TIDB_HOST = "TIDB_HOST";
+
+  public static final String TIDB_PORT = "TIDB_PORT";
+
+  public static final String TIDB_USER = "TIDB_USER";
+
+  public static final String TIDB_PASSWORD = "TIDB_PASSWORD";
+
+  public static final String tidbHost = getEnvOrDefault(TIDB_HOST, "127.0.0.1");
+
+  public static final String tidbPort = getEnvOrDefault(TIDB_PORT, "4000");
+
+  public static final String tidbUser = getEnvOrDefault(TIDB_USER, "root");
+
+  public static final String tidbPassword = getEnvOrDefault(TIDB_PASSWORD, "");
+
+  private static String getEnvOrDefault(String key, String default0) {
+    String tmp = System.getenv(key);
+    if (tmp != null && !tmp.equals("")) {
+      return tmp;
+    }
+
+    tmp = System.getProperty(key);
+    if (tmp != null && !tmp.equals("")) {
+      return tmp;
+    }
+
+    return default0;
+  }
+
+  public static final String CATALOG_NAME = "tidb";
+
+  public static final String DATABASE_NAME = "test";
+
+  public static final String CREATE_DATABASE_SQL = "CREATE DATABASE IF NOT EXISTS `test`";
+
+  public static final String CREATE_TABLE_SQL_FORMAT =
+      "CREATE TABLE IF NOT EXISTS `%s`.`%s`\n"
+          + "(\n"
+          + "    c1  tinyint,\n"
+          + "    c2  smallint,\n"
+          + "    c3  mediumint,\n"
+          + "    c4  int,\n"
+          + "    c5  bigint,\n"
+          + "    c6  char(10),\n"
+          + "    c7  varchar(20),\n"
+          + "    c8  tinytext,\n"
+          + "    c9  mediumtext,\n"
+          + "    c10 text,\n"
+          + "    c11 longtext,\n"
+          + "    c12 binary(20),\n"
+          + "    c13 varbinary(20),\n"
+          + "    c14 tinyblob,\n"
+          + "    c15 mediumblob,\n"
+          + "    c16 blob,\n"
+          + "    c17 longblob,\n"
+          + "    c18 float,\n"
+          + "    c19 double,\n"
+          + "    c20 decimal(6, 3),\n"
+          + "    c21 date,\n"
+          + "    c22 time,\n"
+          + "    c23 datetime,\n"
+          + "    c24 timestamp,\n"
+          + "    c25 year,\n"
+          + "    c26 boolean,\n"
+          + "    c27 json,\n"
+          + "    c28 enum ('1','2','3'),\n"
+          + "    c29 set ('a','b','c'),\n"
+          + "    PRIMARY KEY(c1),\n"
+          + "    UNIQUE KEY(c2)\n"
+          + ")";
+
+  public static final String DROP_TABLE_SQL_FORMAT = "DROP TABLE IF EXISTS `%s`.`%s`";
+
+  // for write mode, only unique key and primary key is mutable.
+  public static final String INSERT_ROW_SQL_FORMAT =
+      "INSERT INTO `%s`.`%s`.`%s`\n"
+          + "VALUES (\n"
+          + " cast(%s as tinyint) ,\n"
+          + " cast(%s as smallint) ,\n"
+          + " cast(1 as int) ,\n"
+          + " cast(1 as int) ,\n"
+          + " cast(1 as bigint) ,\n"
+          + " cast('chartype' as char(10)),\n"
+          + " cast('varchartype' as varchar(20)),\n"
+          + " cast('tinytexttype' as string),\n"
+          + " cast('mediumtexttype' as string),\n"
+          + " cast('texttype' as string),\n"
+          + " cast('longtexttype' as string),\n"
+          + " cast('binarytype' as bytes),\n"
+          + " cast('varbinarytype' as bytes),\n"
+          + " cast('tinyblobtype' as bytes),\n"
+          + " cast('mediumblobtype' as bytes),\n"
+          + " cast('blobtype' as bytes),\n"
+          + " cast('longblobtype' as bytes),\n"
+          + " cast(1.234 as float),\n"
+          + " cast(2.456789 as double),\n"
+          + " cast(123.456 as decimal(6,3)),\n"
+          + " cast('2020-08-10' as date),\n"
+          + " cast('15:30:29' as time),\n"
+          + " cast('2020-08-10 15:30:29' as timestamp),\n"
+          + " cast('2020-08-10 16:30:29' as timestamp),\n"
+          + " cast(2020 as smallint),\n"
+          + " true,\n"
+          + " cast('{\"a\":1,\"b\":2}' as string),\n"
+          + " cast('1' as string),\n"
+          + " cast('a' as string)\n"
+          + ")";
+
+  public static final String CREATE_DATAGEN_TABLE_SQL = "CREATE TABLE datagen (\n"
+      + " c1 int,\n"
+      + " proctime as PROCTIME()\n"
+      + ") WITH (\n"
+      + " 'connector' = 'datagen',\n"
+      + " 'rows-per-second'='10',\n"
+      + " 'fields.c1.kind'='random',\n"
+      + " 'fields.c1.min'='1',\n"
+      + " 'fields.c1.max'='10',\n"
+      + " 'number-of-rows'='10'\n"
+      + ")";
+
+  public static String getInsertRowSql(String tableName, byte value1, short value2) {
+    return format(INSERT_ROW_SQL_FORMAT, CATALOG_NAME, DATABASE_NAME, tableName, value1, value2);
+  }
+
+  public static String getCreateTableSql(String tableName) {
+    return String.format(CREATE_TABLE_SQL_FORMAT, DATABASE_NAME, tableName);
+  }
+
+  public static String getDropTableSql(String tableName) {
+    return String.format(DROP_TABLE_SQL_FORMAT, DATABASE_NAME, tableName);
+  }
+
+  public static String getRandomTableName() {
+    return UUID.randomUUID().toString().replace("-", "_");
+  }
+
+  public Map<String, String> getDefaultProperties() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(DATABASE_URL,
+        String.format(
+            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false",
+            tidbHost, tidbPort));
+    properties.put(USERNAME, tidbUser);
+    properties.put(PASSWORD, tidbPassword);
+    properties.put(MAX_POOL_SIZE, "1");
+    properties.put(MIN_IDLE_SIZE, "1");
+    return properties;
+  }
+
+  public TableEnvironment getTableEnvironment() {
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner()
+        .inBatchMode().build();
+    return TableEnvironment.create(settings);
+  }
+
+  public Row runByCatalog(Map<String, String> properties) throws Exception {
+    return runByCatalog(properties, null, null);
+  }
+
+  public Row runByCatalog(Map<String, String> properties, String resultSql, String tableName)
+      throws Exception {
+    // env
+    TableEnvironment tableEnvironment = getTableEnvironment();
+    // create test database and table
+    TiDBCatalog tiDBCatalog = new TiDBCatalog(properties);
+    tiDBCatalog.open();
+    if (tableName == null) {
+      tableName = getRandomTableName();
+    }
+    String dropTableSql = getDropTableSql(tableName);
+    String createTableSql = getCreateTableSql(tableName);
+    tiDBCatalog.sqlUpdate(CREATE_DATABASE_SQL, dropTableSql, createTableSql);
+    // register catalog
+    tableEnvironment.registerCatalog(CATALOG_NAME, tiDBCatalog);
+    // insert data
+    tableEnvironment.executeSql(getInsertRowSql(tableName, (byte) 1, (short) 1));
+    tableEnvironment.executeSql(getInsertRowSql(tableName, (byte) 1, (short) 2));
+    // query
+    if (resultSql == null) {
+      resultSql = format("SELECT * FROM `%s`.`%s`.`%s`", CATALOG_NAME, DATABASE_NAME, tableName);
+    }
+    TableResult tableResult = tableEnvironment.executeSql(resultSql);
+    Row row = tableResult.collect().next();
+    tiDBCatalog.sqlUpdate(dropTableSql);
+    return row;
+  }
+
+  public Row copyRow(Row row) {
+    Row newRow = new Row(row.getArity());
+    for (int i = 0; i < row.getArity(); i++) {
+      newRow.setField(i, row.getField(i));
+    }
+    return newRow;
+  }
+
+  public Row copyRow(Row row, int[] indexes) {
+    Row newRow = new Row(indexes.length);
+    for (int i = 0; i < indexes.length; i++) {
+      newRow.setField(i, row.getField(indexes[i]));
+    }
+    return newRow;
+  }
+
+  public Row replicaRead() throws Exception {
+    Map<String, String> properties = getDefaultProperties();
+    properties.put(TIDB_REPLICA_READ, "true");
+    return runByCatalog(properties);
+  }
+
+  public Row upsertAndRead() throws Exception {
+    Map<String, String> properties = getDefaultProperties();
+    properties.put(TIDB_WRITE_MODE, "upsert");
+    return runByCatalog(properties);
+  }
+
+  @Test
+  public void testTableFactory() throws Exception {
+    // only test for timestamp
+    // env
+    TableEnvironment tableEnvironment = getTableEnvironment();
+    Map<String, String> properties = getDefaultProperties();
+    properties.put("connector", "tidb");
+    properties.put(TiDBConfigOptions.DATABASE_NAME.key(), "test");
+    properties.put(TiDBConfigOptions.TABLE_NAME.key(), "test_timestamp");
+    properties.put("timestamp-format.c1", "yyyy-MM-dd HH:mm:ss");
+    properties.put("timestamp-format.c2", "yyyy-MM-dd HH:mm:ss");
+    // create test database and table
+    TiDBCatalog tiDBCatalog = new TiDBCatalog(properties);
+    tiDBCatalog.open();
+    tiDBCatalog.sqlUpdate("DROP TABLE IF EXISTS `test_timestamp`");
+    tiDBCatalog.sqlUpdate("CREATE TABLE `test_timestamp`(`c1` VARCHAR(255), `c2` timestamp)",
+        "INSERT INTO `test_timestamp` VALUES('2020-01-01 12:00:01','2020-01-01 12:00:02')");
+    String propertiesString = properties.entrySet().stream()
+        .map(entry -> format("'%s' = '%s'", entry.getKey(), entry.getValue())).collect(
+            Collectors.joining(",\n"));
+    String createTableSql = format(
+        "CREATE TABLE `test_timestamp`(`c1` timestamp, `c2` string) WITH (\n%s\n)",
+        propertiesString);
+    tableEnvironment.executeSql(createTableSql);
+    Row row = tableEnvironment.executeSql("SELECT * FROM `test_timestamp`").collect().next();
+    Row row1 = new Row(2);
+    row1.setField(0, LocalDateTime.of(2020, 1, 1, 12, 0, 1));
+    row1.setField(1, "2020-01-01 12:00:02");
+    Assert.assertEquals(row, row1);
+
+    tableEnvironment.executeSql("DROP TABLE `test_timestamp`");
+    createTableSql = format(
+        "CREATE TABLE `test_timestamp`(`c2` string) WITH (\n%s\n)", propertiesString);
+    tableEnvironment.executeSql(createTableSql);
+    row = tableEnvironment.executeSql("SELECT * FROM `test_timestamp`").collect().next();
+    row1 = new Row(1);
+    row1.setField(0, "2020-01-01 12:00:02");
+    Assert.assertEquals(row, row1);
+    tiDBCatalog.close();
+  }
+
+  @Test
+  public void testCatalog() throws Exception {
+    // read by limit
+    String tableName = getRandomTableName();
+    Row row = runByCatalog(getDefaultProperties(),
+        format("SELECT * FROM `%s`.`%s`.`%s` LIMIT 1", CATALOG_NAME, DATABASE_NAME, tableName),
+        tableName);
+    // replica read
+    Assert.assertEquals(row, replicaRead());
+    // upsert and read
+    Row row1 = copyRow(row);
+    row1.setField(0, (byte) 1);
+    row1.setField(1, (short) 2);
+    Assert.assertEquals(row1, upsertAndRead());
+    // filter push down
+    tableName = getRandomTableName();
+    Assert.assertEquals(row,
+        runByCatalog(getDefaultProperties(),
+            format("SELECT * FROM `%s`.`%s`.`%s` WHERE (c1 = 1 OR c3 = 1) AND c2 = 1",
+                CATALOG_NAME, DATABASE_NAME, tableName),
+            tableName));
+    // column pruner
+    tableName = getRandomTableName();
+    // select 10 column randomly
+    Random random = new Random();
+    int[] ints = IntStream.range(0, 10).map(i -> random.nextInt(29)).toArray();
+    row1 = runByCatalog(getDefaultProperties(),
+        format("SELECT %s FROM `%s`.`%s`.`%s` LIMIT 1",
+            Arrays.stream(ints).mapToObj(i -> "c" + (i + 1)).collect(Collectors.joining(",")),
+            CATALOG_NAME, DATABASE_NAME, tableName),
+        tableName);
+    Assert.assertEquals(row1, copyRow(row, ints));
+  }
+
+  @Test
+  public void testLookupTableSource() throws Exception {
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner()
+        .inStreamingMode().build();
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(env, settings);
+    Map<String, String> properties = getDefaultProperties();
+    TiDBCatalog tiDBCatalog = new TiDBCatalog(properties);
+    tiDBCatalog.open();
+    String tableName = getRandomTableName();
+    String createTableSql1 = String
+        .format("CREATE TABLE `%s`.`%s` (c1 int, c2 varchar(255), PRIMARY KEY(`c1`))",
+            DATABASE_NAME, tableName);
+    String insertDataSql = String
+        .format("INSERT INTO `%s`.`%s` VALUES (1,'data1'),(2,'data2'),(3,'data3'),(4,'data4')",
+            DATABASE_NAME, tableName);
+    tiDBCatalog.sqlUpdate(createTableSql1, insertDataSql);
+    tableEnvironment.registerCatalog("tidb", tiDBCatalog);
+    tableEnvironment.executeSql(CREATE_DATAGEN_TABLE_SQL);
+    String sql = String.format(
+        "SELECT * FROM `datagen` "
+            + "LEFT JOIN `%s`.`%s`.`%s` FOR SYSTEM_TIME AS OF datagen.proctime AS `dim_table` "
+            + "ON datagen.c1 = dim_table.c1 ",
+        "tidb", DATABASE_NAME, tableName);
+    CloseableIterator<Row> iterator = tableEnvironment.executeSql(sql).collect();
+    while (iterator.hasNext()) {
+      Row row = iterator.next();
+      Object c1 = row.getField(0);
+      String c2 = String.format("data%s", c1);
+      boolean isJoin = (int) c1 <= 4;
+      Row row1 = Row.of(c1, row.getField(1), isJoin ? c1 : null, isJoin ? c2 : null);
+      Assert.assertEquals(row, row1);
+    }
+  }
+}

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/JdbcUtils.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/JdbcUtils.java
@@ -16,11 +16,11 @@
 
 package io.tidb.bigdata.flink.tidb;
 
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.DATABASE_NAME;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.DATABASE_URL;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.PASSWORD;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.TABLE_NAME;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.USERNAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_URL;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.PASSWORD;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.USERNAME;
 import static io.tidb.bigdata.jdbc.TiDBDriver.MYSQL_DRIVER_NAME;
 import static io.tidb.bigdata.jdbc.TiDBDriver.TIDB_PREFIX;
 import static io.tidb.bigdata.tidb.ClientConfig.TIDB_DRIVER_NAME;

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseCatalog.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseCatalog.java
@@ -16,8 +16,9 @@
 
 package io.tidb.bigdata.flink.tidb;
 
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.DATABASE_NAME;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.TABLE_NAME;
+
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
 
 import com.google.common.collect.ImmutableMap;
 import io.tidb.bigdata.tidb.ClientConfig;

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseCatalogFactory.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseCatalogFactory.java
@@ -24,8 +24,6 @@ import static io.tidb.bigdata.tidb.ClientConfig.TIDB_FILTER_PUSH_DOWN;
 import static io.tidb.bigdata.tidb.ClientConfig.TIDB_REPLICA_READ;
 import static io.tidb.bigdata.tidb.ClientConfig.TIDB_WRITE_MODE;
 import static io.tidb.bigdata.tidb.ClientConfig.USERNAME;
-import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
-import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_TYPE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,6 +34,8 @@ import org.apache.flink.table.factories.CatalogFactory;
 public abstract class TiDBBaseCatalogFactory implements CatalogFactory {
 
   public static final String CATALOG_TYPE_VALUE_TIDB = "tidb";
+  public static final String CATALOG_PROPERTY_VERSION = "property-version";
+  public static final String CATALOG_TYPE = "type";
 
   @Override
   public Map<String, String> requiredContext() {

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseDynamicTableFactory.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseDynamicTableFactory.java
@@ -16,14 +16,28 @@
 
 package io.tidb.bigdata.flink.tidb;
 
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_URL;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.IDENTIFIER;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.LOOKUP_CACHE_MAX_ROWS;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.LOOKUP_CACHE_TTL;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.LOOKUP_MAX_RETRIES;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.MAX_POOL_SIZE;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.MIN_IDLE_SIZE;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.PASSWORD;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.SINK_BUFFER_FLUSH_INTERVAL;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.SINK_MAX_RETRIES;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.USERNAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.WRITE_MODE;
+
 import com.google.common.collect.ImmutableSet;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.TiDBWriteMode;
-import java.time.Duration;
 import java.util.Set;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
@@ -38,76 +52,6 @@ import org.apache.flink.table.factories.FactoryUtil;
 
 public abstract class TiDBBaseDynamicTableFactory implements DynamicTableSourceFactory,
     DynamicTableSinkFactory {
-
-  public static final String IDENTIFIER = "tidb";
-
-  public static final ConfigOption<String> DATABASE_URL = ConfigOptions
-      .key(ClientConfig.DATABASE_URL).stringType().noDefaultValue();
-
-  public static final ConfigOption<String> USERNAME = ConfigOptions.key(ClientConfig.USERNAME)
-      .stringType().noDefaultValue();
-
-  public static final ConfigOption<String> PASSWORD = ConfigOptions.key(ClientConfig.PASSWORD)
-      .stringType().noDefaultValue();
-
-  public static final ConfigOption<String> DATABASE_NAME = ConfigOptions
-      .key("tidb.database.name").stringType().noDefaultValue();
-
-  public static final ConfigOption<String> TABLE_NAME = ConfigOptions
-      .key("tidb.table.name").stringType().noDefaultValue();
-
-  public static final ConfigOption<String> MAX_POOL_SIZE = ConfigOptions
-      .key(ClientConfig.MAX_POOL_SIZE).stringType().noDefaultValue();
-
-  public static final ConfigOption<String> MIN_IDLE_SIZE = ConfigOptions
-      .key(ClientConfig.MIN_IDLE_SIZE).stringType().noDefaultValue();
-
-  public static final ConfigOption<String> WRITE_MODE = ConfigOptions
-      .key(ClientConfig.TIDB_WRITE_MODE).stringType()
-      .defaultValue(ClientConfig.TIDB_WRITE_MODE_DEFAULT);
-
-  /**
-   * see ${@link org.apache.flink.connector.jdbc.table.JdbcDynamicTableFactory}
-   */
-  public static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS = ConfigOptions
-      .key("sink.buffer-flush.max-rows")
-      .intType()
-      .defaultValue(100)
-      .withDescription(
-          "the flush max size (includes all append, upsert and delete records), over this number"
-              + " of records, will flush data. The default value is 100.");
-  private static final ConfigOption<Duration> SINK_BUFFER_FLUSH_INTERVAL = ConfigOptions
-      .key("sink.buffer-flush.interval")
-      .durationType()
-      .defaultValue(Duration.ofSeconds(1))
-      .withDescription(
-          "the flush interval mills, over this time, asynchronous threads will flush data. The "
-              + "default value is 1s.");
-  public static final ConfigOption<Integer> SINK_MAX_RETRIES = ConfigOptions
-      .key("sink.max-retries")
-      .intType()
-      .defaultValue(3)
-      .withDescription("the max retry times if writing records to database failed.");
-
-  // look up config options
-  public static final ConfigOption<Long> LOOKUP_CACHE_MAX_ROWS = ConfigOptions
-      .key("lookup.cache.max-rows")
-      .longType()
-      .defaultValue(-1L)
-      .withDescription("the max number of rows of lookup cache, over this value, "
-          + "the oldest rows will be eliminated. \"cache.max-rows\" and \"cache.ttl\" options "
-          + "must all be specified if any of them is specified. "
-          + "Cache is not enabled as default.");
-  public static final ConfigOption<Duration> LOOKUP_CACHE_TTL = ConfigOptions
-      .key("lookup.cache.ttl")
-      .durationType()
-      .defaultValue(Duration.ofSeconds(10))
-      .withDescription("the cache time to live.");
-  public static final ConfigOption<Integer> LOOKUP_MAX_RETRIES = ConfigOptions
-      .key("lookup.max-retries")
-      .intType()
-      .defaultValue(3)
-      .withDescription("the max retry times if lookup database failed.");
 
   @Override
   public String factoryIdentifier() {

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseRowDataInputFormat.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseRowDataInputFormat.java
@@ -16,8 +16,8 @@
 
 package io.tidb.bigdata.flink.tidb;
 
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.DATABASE_NAME;
-import static io.tidb.bigdata.flink.tidb.TiDBBaseDynamicTableFactory.TABLE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.DATABASE_NAME;
+import static io.tidb.bigdata.flink.tidb.TiDBConfigOptions.TABLE_NAME;
 import static io.tidb.bigdata.flink.tidb.TypeUtils.getObjectWithDataType;
 import static io.tidb.bigdata.flink.tidb.TypeUtils.toRowDataType;
 import static java.lang.String.format;

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBConfigOptions.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBConfigOptions.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.flink.tidb;
+
+import static io.tidb.bigdata.tidb.ClientConfig.TIDB_FILTER_PUSH_DOWN;
+import static io.tidb.bigdata.tidb.ClientConfig.TIDB_FILTER_PUSH_DOWN_DEFAULT;
+import static io.tidb.bigdata.tidb.ClientConfig.TIDB_REPLICA_READ;
+import static io.tidb.bigdata.tidb.ClientConfig.TIDB_REPLICA_READ_DEFAULT;
+
+import io.tidb.bigdata.tidb.ClientConfig;
+import java.time.Duration;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/**
+ * A collection of {@link ConfigOption} which are used in tidb catalog and table
+ */
+public class TiDBConfigOptions {
+
+  public static final String IDENTIFIER = "tidb";
+
+  public static final ConfigOption<String> DATABASE_URL =
+      ConfigOptions.key(ClientConfig.DATABASE_URL).stringType().noDefaultValue();
+
+  public static final ConfigOption<String> USERNAME =
+      ConfigOptions.key(ClientConfig.USERNAME).stringType().noDefaultValue();
+
+  public static final ConfigOption<String> PASSWORD =
+      ConfigOptions.key(ClientConfig.PASSWORD).stringType().noDefaultValue();
+
+  public static final ConfigOption<String> DATABASE_NAME =
+      ConfigOptions.key("tidb.database.name").stringType().noDefaultValue();
+
+  public static final ConfigOption<String> TABLE_NAME =
+      ConfigOptions.key("tidb.table.name").stringType().noDefaultValue();
+
+  public static final ConfigOption<String> MAX_POOL_SIZE =
+      ConfigOptions.key(ClientConfig.MAX_POOL_SIZE).stringType().noDefaultValue();
+
+  public static final ConfigOption<String> MIN_IDLE_SIZE =
+      ConfigOptions.key(ClientConfig.MIN_IDLE_SIZE).stringType().noDefaultValue();
+
+  public static final ConfigOption<String> WRITE_MODE =
+      ConfigOptions.key(ClientConfig.TIDB_WRITE_MODE)
+          .stringType()
+          .defaultValue(ClientConfig.TIDB_WRITE_MODE_DEFAULT);
+
+  public static final ConfigOption<Boolean> REPLICA_READ =
+      ConfigOptions.key(TIDB_REPLICA_READ)
+          .booleanType()
+          .defaultValue(TIDB_REPLICA_READ_DEFAULT);
+
+  public static final ConfigOption<Boolean> FILTER_PUSH_DOWN =
+      ConfigOptions.key(TIDB_FILTER_PUSH_DOWN)
+          .booleanType()
+          .defaultValue(TIDB_FILTER_PUSH_DOWN_DEFAULT);
+
+  /**
+   * see ${@link org.apache.flink.connector.jdbc.table.JdbcDynamicTableFactory}
+   */
+  public static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS =
+      ConfigOptions.key("sink.buffer-flush.max-rows")
+          .intType()
+          .defaultValue(100)
+          .withDescription(
+              "the flush max size (includes all append, upsert and delete records),"
+                  + " over this number of records, will flush data. The default value is 100.");
+
+  public static final ConfigOption<Duration> SINK_BUFFER_FLUSH_INTERVAL =
+      ConfigOptions.key("sink.buffer-flush.interval")
+          .durationType()
+          .defaultValue(Duration.ofSeconds(1))
+          .withDescription(
+              "the flush interval mills, over this time, asynchronous threads will flush data. The "
+                  + "default value is 1s.");
+
+  public static final ConfigOption<Integer> SINK_MAX_RETRIES =
+      ConfigOptions.key("sink.max-retries")
+          .intType()
+          .defaultValue(3)
+          .withDescription("the max retry times if writing records to database failed.");
+
+  // look up config options
+  public static final ConfigOption<Long> LOOKUP_CACHE_MAX_ROWS =
+      ConfigOptions.key("lookup.cache.max-rows")
+          .longType()
+          .defaultValue(-1L)
+          .withDescription("the max number of rows of lookup cache, over this value, "
+              + "the oldest rows will be eliminated. \"cache.max-rows\" and \"cache.ttl\" options "
+              + "must all be specified if any of them is specified. "
+              + "Cache is not enabled as default.");
+
+  public static final ConfigOption<Duration> LOOKUP_CACHE_TTL =
+      ConfigOptions.key("lookup.cache.ttl")
+          .durationType()
+          .defaultValue(Duration.ofSeconds(10))
+          .withDescription("the cache time to live.");
+
+  public static final ConfigOption<Integer> LOOKUP_MAX_RETRIES =
+      ConfigOptions.key("lookup.max-retries")
+          .intType()
+          .defaultValue(3)
+          .withDescription("the max retry times if lookup database failed.");
+
+
+}

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -23,6 +23,7 @@
     <modules>
         <module>flink-1.11</module>
         <module>flink-1.12</module>
+        <module>flink-1.13</module>
         <module>flink-base</module>
     </modules>
 


### PR DESCRIPTION
Provides support improvements to `flink-tidb-connector` for Flink-1.13.

**The following steps are included:**

* **[[cf8d5b0]](https://github.com/tidb-incubator/TiBigData/commit/cf8d5b0d67c994ca1c766bea26a5faf14b3787fc)**  

  Remove constants `CATALOG_PROPERTY_VERSION`, `CATALOG_TYPE` that are not supported in Flink-1.13, and set them to internal static constants of `TiDBBaseCatalogFactory` for compatibility with Flink-1.12 and Flink-1.11.

* **[[c167006]](https://github.com/tidb-incubator/TiBigData/commit/c1670068b74cd37aab5faf05e50c099cb8f1ec7e)**

  Move the `ConfigOption` properties associated with `TiDBClient` in `TiDBDynamicTableFactory` to a separate class `TiDBConfigOptions` to enable clearer configuration sharing.

* **[[72ec25a]](https://github.com/tidb-incubator/TiBigData/commit/72ec25a0519aedd0ef41b06bc14b5b8a0605c8c6)**

  Add A new flink-connector-1.13 module. In order to better follow the Flink-1.13 [`CatalogFactory`](https://github.com/apache/flink/blob/release-1.13/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/CatalogFactory.java) API  which has been significantly changed from Flink-1.11 and 1.12 , The  [`TiDBCatalogFactory`](https://github.com/tidb-incubator/TiBigData/commit/72ec25a0519aedd0ef41b06bc14b5b8a0605c8c6#diff-399017e9241b83c696f0a32da0833ea1500a157e6d509218e6e3d6f693d8e808) directly inherits the `CatalogFactory` API and re-implements it.

* **[[45eb5a6]](https://github.com/tidb-incubator/TiBigData/commit/45eb5a6b9af66e6ac372612429273d26179ca575)**

  Add the necessary notes to the README.md.

* **[[8d3980d]](https://github.com/tidb-incubator/TiBigData/commit/8d3980d6a81834fb72e6d419266399da9e237855)**

  Add CI related to flink-connector-1.13 module.
