### PR TITLE
Fix the wrong literal of timestamp-format

### DIFF
--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/TiDBOptions.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/TiDBOptions.java
@@ -73,7 +73,7 @@ public class TiDBOptions {
   public static final Set<String> VALID_STREAMING_CODECS =
       ImmutableSet.of(STREAMING_CODEC_CRAFT, STREAMING_CODEC_JSON);
 
-  public static final String TIMESTAMP_FORMAT_PREFIX = "tidb.timestamp-format.";
+  public static final String TIMESTAMP_FORMAT_PREFIX = "timestamp-format.";
 
   public static Set<ConfigOption<?>> requiredOptions() {
     return withMoreRequiredOptions();


### PR DESCRIPTION
Signed-off-by: Al-assad yulin.ying@outlook.com

According to the [documentation](https://github.com/tidb-incubator/TiBigData/tree/master/flink#configuration), the special time formatting configuration should be `timestamp-format.${columnName}` instead of `tidb.timestamp-format.${columnName}` 