### PR TITLE
MapReduce connector: support internal cluster TLS

### DIFF
--- a/.ci/build-client-java.sh
+++ b/.ci/build-client-java.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#/bin/bash
 
 set -x
 set -euo pipefail
 
 git clone https://github.com/tikv/client-java.git
 cd client-java
-git reset --hard 309c521e9842ee9717ce12cd54513641fdb0b8eb
+git reset --hard 28380512f3adacc1acb54daa381c4c71b1a1fa8f
 mvn install -DskipTests
 cd ..
 rm -Rf client-java

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBConfiguration.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBConfiguration.java
@@ -41,6 +41,12 @@ public class TiDBConfiguration {
   /** Password to access the database */
   public static final String PASSWORD_PROPERTY = "mapreduce.jdbc.password";
 
+  /** Cluster TLS configuration */
+  public static final String CLUSTER_TLS_ENABLE = "tidb.cluster-tls-enable";
+  public static final String CLUSTER_TLS_CA = "tidb.cluster-tls-ca";
+  public static final String CLUSTER_TLS_KEY = "tidb.cluster-tls-key";
+  public static final String CLUSTER_TLS_CERT = "tidb.cluster-tls-cert";
+
   /** Input table name */
   public static final String INPUT_TABLE_NAME_PROPERTY = "mapreduce.jdbc.input.table.name";
 
@@ -71,11 +77,18 @@ public class TiDBConfiguration {
    */
   public static void configureDB(Configuration conf,
       String dbUrl, String databaseName, String userName, String password) {
-
     conf.set(URL_PROPERTY, dbUrl);
     conf.set(DATABASE_NAME, databaseName);
     conf.set(USERNAME_PROPERTY, userName);
     conf.set(PASSWORD_PROPERTY, password);
+  }
+
+  public static void clusterTls(Configuration conf,
+      String ca, String cert, String key) {
+    conf.set(CLUSTER_TLS_ENABLE, "true");
+    conf.set(CLUSTER_TLS_CA, ca);
+    conf.set(CLUSTER_TLS_CERT, cert);
+    conf.set(CLUSTER_TLS_KEY, key);
   }
 
   private Configuration conf;
@@ -90,6 +103,10 @@ public class TiDBConfiguration {
     properties.put(ClientConfig.DATABASE_URL, conf.get(URL_PROPERTY));
     properties.put(ClientConfig.USERNAME, conf.get(USERNAME_PROPERTY));
     properties.put(ClientConfig.PASSWORD, conf.get(PASSWORD_PROPERTY));
+    properties.put(ClientConfig.CLUSTER_TLS_ENABLE, conf.get(CLUSTER_TLS_ENABLE));
+    properties.put(ClientConfig.CLUSTER_TLS_CA, conf.get(CLUSTER_TLS_CA));
+    properties.put(ClientConfig.CLUSTER_TLS_KEY, conf.get(CLUSTER_TLS_KEY));
+    properties.put(ClientConfig.CLUSTER_TLS_CERT, conf.get(CLUSTER_TLS_CERT));
 
     return ClientSession.createWithSingleConnection(new ClientConfig(properties));
   }

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/example/MapreduceCmd.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/example/MapreduceCmd.java
@@ -35,6 +35,18 @@ public class MapreduceCmd {
       "-p"}, description = "password", password = true, required = true)
   public String password;
 
+  @Parameter(names = {"-clusterTls"}, description = "enable cluster TLS")
+  public boolean clusterTlsEnabled = false;
+
+  @Parameter(names = {"-clusterTlsCA"}, description = "cluster TLS CA")
+  public String clusterTlsCA;
+
+  @Parameter(names = {"-clusterTlsCert"}, description = "cluster TLS certificate")
+  public String clusterTlsCert;
+
+  @Parameter(names = {"-clusterTlsKey"}, description = "cluster TLS key")
+  public String clusterTlsKey;
+
   @Parameter(names = {"-databasename", "-dn"}, description = "database name", required = true)
   public String databaseName;
 

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/example/TiDBMapreduceDemo.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/example/TiDBMapreduceDemo.java
@@ -41,8 +41,12 @@ public class TiDBMapreduceDemo {
     MapreduceCmd cmd = new MapreduceCmd(args);
 
     Configuration conf = new Configuration();
-    TiDBConfiguration.configureDB(conf, cmd.databaseUrl, cmd.databaseName, cmd.username,
-        cmd.password);
+    TiDBConfiguration.configureDB(conf,
+        cmd.databaseUrl, cmd.databaseName, cmd.username, cmd.password);
+    if (cmd.clusterTlsEnabled) {
+      TiDBConfiguration.clusterTls(conf,
+          cmd.clusterTlsCA, cmd.clusterTlsCert, cmd.clusterTlsKey);
+    }
     Job job = Job.getInstance(conf, "MRFormTiDB");
     TiDBInputFormat.setInput(job, TiDBRowData.class, cmd.tableName,
         cmd.fields.isEmpty() ? null : cmd.fields.toArray(new String[0]), cmd.limit, cmd.timestamp);

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
@@ -101,6 +101,12 @@ public final class ClientSession implements AutoCloseable {
     hostMapping = new DnsSearchHostMapping(config.getDnsSearch());
     loadPdAddresses();
     TiConfiguration tiConfiguration = TiConfiguration.createDefault(config.getPdAddresses());
+
+    tiConfiguration.setTlsEnable(config.getClusterTlsEnabled());
+    tiConfiguration.setTrustCertCollectionFile(Optional.of(config.getClusterTlsCA()));
+    tiConfiguration.setKeyCertChainFile(Optional.of(config.getClusterTlsCert()));
+    tiConfiguration.setKeyFile(Optional.of(config.getClusterTlsKey()));
+
     tiConfiguration.setTimeout(config.getTimeout());
     tiConfiguration.setScanTimeout(config.getScanTimeout());
     ReplicaReadPolicy policy = config.getReplicaReadPolicy();

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
@@ -103,9 +103,9 @@ public final class ClientSession implements AutoCloseable {
     TiConfiguration tiConfiguration = TiConfiguration.createDefault(config.getPdAddresses());
 
     tiConfiguration.setTlsEnable(config.getClusterTlsEnabled());
-    tiConfiguration.setTrustCertCollectionFile(Optional.of(config.getClusterTlsCA()));
-    tiConfiguration.setKeyCertChainFile(Optional.of(config.getClusterTlsCert()));
-    tiConfiguration.setKeyFile(Optional.of(config.getClusterTlsKey()));
+    tiConfiguration.setTrustCertCollectionFile(config.getClusterTlsCA());
+    tiConfiguration.setKeyCertChainFile(config.getClusterTlsCert());
+    tiConfiguration.setKeyFile(config.getClusterTlsKey());
 
     tiConfiguration.setTimeout(config.getTimeout());
     tiConfiguration.setScanTimeout(config.getScanTimeout());


### PR DESCRIPTION
Add support for internal cluster TS to MapReduce connector.

Call `TiDBConfiguration.clusterTls` if you want to enable internal TLS.


Note that if you require TLS support for the MySQL-protocol connection to tidb-server (typically on port 4000), you can achieve that by setting appropriate properties or URI configuration properties for MySQL Connector/J. See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html for details. Example:

```
HADOOP_OPTS="$HADOOP_OPTS 
  -Djavax.net.ssl.trustStore=$PWD/truststore
  -Djavax.net.ssl.trustStorePassword=mypassword
  -Djavax.net.ssl.keyStore=/home/ubuntu/keystore 
  -Djavax.net.ssl.keyStorePassword=mypassword " \
~/hadoop-2.10.1/bin/hadoop jar mapreduce/mapreduce-base/target/mapreduce-tidb-connector-base-0.0.5-SNAPSHOT.jar  io.tidb.bigdata.mapreduce.tidb.example.TiDBMapreduceDemo \
-du "jdbc:mysql://127.0.0.1:4000/test?enabledTLSProtocols=TLSv1.3"  \
-clusterTls -clusterTlsCA /home/ubuntu/.tiup/storage/cluster/clusters/test/tls/ca.crt \
-clusterTlsCert /home/ubuntu/.tiup/storage/cluster/clusters/test/tls/client.crt \
-clusterTlsKey /home/ubuntu/.tiup/storage/cluster/clusters/test/tls/client.p8 ...
```

Or you can add the tidb-server CA to the default/system truststore and use the configuration properties like this for the keystore:
```
-du "jdbc:mysql://127.0.0.1:4000/test?enabledTLSProtocols=TLSv1.3&clientCertificateKeyStoreUrl=file:$HOME/keystore&clientCertificateKeyStorePassword=mypassword"
```