### PR TITLE
Make JDBC driver discovery thread a daemon thread

### DIFF
--- a/jdbc/driver/src/main/java/io/tidb/bigdata/jdbc/LoadBalancingDriver.java
+++ b/jdbc/driver/src/main/java/io/tidb/bigdata/jdbc/LoadBalancingDriver.java
@@ -109,6 +109,7 @@ public class LoadBalancingDriver implements Driver {
         (runnable) -> {
           Thread newThread = new Thread(runnable);
           newThread.setName("TiDB JDBC Driver Executor Thread - " + threadId.getAndIncrement());
+          newThread.setDaemon(true);
           return newThread;
         });
     this.executor.setKeepAliveTime(minReloadInterval * 2, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
JDBC driver discovery thread is not daemon thread. This prevents JVM from exiting even after main thread terminates.