### PR TITLE
distinguish unit tests and integration tests

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -5,17 +5,17 @@ set -euo pipefail
 
 .ci/build-client-java.sh
 
-mvn clean compile -am -pl ticdc
-mvn clean compile -am -pl flink/flink-1.11
-mvn clean compile -am -pl flink/flink-1.12
-mvn clean compile -am -pl flink/flink-1.13
-mvn clean compile -am -pl mapreduce/mapreduce-base
-mvn clean compile -am -pl prestodb
-mvn clean compile -am -pl jdbc
-mvn clean compile -am -pl hive/hive-2.2.0
-mvn clean compile -am -pl hive/hive-2.3.6
-mvn clean compile -am -pl hive/hive-3.1.2
+mvn clean compile test -am -pl ticdc
+mvn clean compile test -am -pl flink/flink-1.11
+mvn clean compile test -am -pl flink/flink-1.12
+mvn clean compile test -am -pl flink/flink-1.13
+mvn clean compile test -am -pl mapreduce/mapreduce-base
+mvn clean compile test -am -pl prestodb
+mvn clean compile test -am -pl jdbc
+mvn clean compile test -am -pl hive/hive-2.2.0
+mvn clean compile test -am -pl hive/hive-2.3.6
+mvn clean compile test -am -pl hive/hive-3.1.2
 
 export JAVA_HOME=/home/jenkins/agent/lib/jdk-11.0.12
-mvn clean compile -am -pl prestosql
-mvn clean compile -am -pl trino
+mvn clean compile test -am -pl prestosql
+mvn clean compile test -am -pl trino

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,14 +9,14 @@ export TIDB_HOST="127.0.0.1"
 export TIDB_PORT="4000"
 export TIDB_USER="root"
 export TIDB_PASSWORD=""
-mvn clean test -am -pl jdbc
-mvn clean test -am -pl ticdc
-mvn clean test -am -pl flink/flink-1.11
-mvn clean test -am -pl flink/flink-1.12
-mvn clean test -am -pl flink/flink-1.13
-mvn clean test -am -pl mapreduce/mapreduce-base
-mvn clean test -am -pl prestodb
+mvn clean test-compile failsafe:integration-test -am -pl jdbc
+mvn clean test-compile failsafe:integration-test -am -pl ticdc
+mvn clean test-compile failsafe:integration-test -am -pl flink/flink-1.11
+mvn clean test-compile failsafe:integration-test -am -pl flink/flink-1.12
+mvn clean test-compile failsafe:integration-test -am -pl flink/flink-1.13
+mvn clean test-compile failsafe:integration-test -am -pl mapreduce/mapreduce-base
+mvn clean test-compile failsafe:integration-test -am -pl prestodb
 
 export JAVA_HOME=/home/jenkins/agent/lib/jdk-11.0.12
-mvn clean test -am -pl prestosql
-mvn clean test -am -pl trino
+mvn clean test-compile failsafe:integration-test -am -pl prestosql
+mvn clean test-compile failsafe:integration-test -am -pl trino

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ First, make sure the module add dependency:
 </dependency>
 ```
 
-Second, use Junit Category to clarify integration-test:
+Second, use JUnit Category to clarify integration-test:
 
 ```java
 import io.tidb.bigdata.test.IntegrationTest;

--- a/README.md
+++ b/README.md
@@ -32,14 +32,43 @@ TiBigData project is under the Apache 2.0 license. See the [LICENSE](./LICENSE) 
 
 ## Run Tests
 
-Use the following command to run all the tests.
+Use the following command to run the integration test.
 
-```
+```bash
 export TIDB_HOST="127.0.0.1"
 export TIDB_PORT="4000"
 export TIDB_USER="root"
 export TIDB_PASSWORD=""
-mvn test
+mvn clean test-compile failsafe:integration-test -am -pl ${MODULE_NAME}
+```
+
+Use the following command to run the unit test.
+
+```
+mvn clean test -am -pl ${MODULE_NAME}
+```
+
+## Write integration test
+
+First, make sure the module add dependency:
+
+```xml
+ <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+</dependency>
+```
+
+Second, use Junit Category to clarify integration-test:
+
+```java
+import io.tidb.bigdata.test.IntegrationTest;
+
+@Category(IntegrationTest.class)
+public class ConnectorsPluginTest {
+}
 ```
 
 ## Community

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -65,7 +65,7 @@ mvn clean test-compile failsafe:integration-test -am -pl ${MODULE_NAME}
 </dependency>
 ```
 
-然后，我们使用 Junit 的 Category 来区分集成测试，用法如下:
+然后，我们使用 JUnit 的 Category 来区分集成测试，用法如下:
 
 ```java
 import io.tidb.bigdata.test.IntegrationTest;

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -39,7 +39,40 @@ export TIDB_HOST="127.0.0.1"
 export TIDB_PORT="4000"
 export TIDB_USER="root"
 export TIDB_PASSWORD=""
-mvn test
+mvn clean test-compile failsafe:integration-test -am -pl ${MODULE_NAME}
+```
+
+使用下面的命令来运行单元测试
+
+```
+export TIDB_HOST="127.0.0.1"
+export TIDB_PORT="4000"
+export TIDB_USER="root"
+export TIDB_PASSWORD=""
+mvn clean test-compile failsafe:integration-test -am -pl ${MODULE_NAME}
+```
+
+## 编写集成测试 
+
+首先，需要确保模块含有以下依赖:
+
+```xml
+ <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+</dependency>
+```
+
+然后，我们使用 Junit 的 Category 来区分集成测试，用法如下:
+
+```java
+import io.tidb.bigdata.test.IntegrationTest;
+
+@Category(IntegrationTest.class)
+public class ConnectorsPluginTest {
+}
 ```
 
 ## 社区

--- a/flink/flink-1.11/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
+++ b/flink/flink-1.11/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
@@ -9,6 +9,7 @@ import static io.tidb.bigdata.tidb.ClientConfig.TIDB_WRITE_MODE;
 import static io.tidb.bigdata.tidb.ClientConfig.USERNAME;
 import static java.lang.String.format;
 
+import io.tidb.bigdata.test.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +29,9 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class FlinkTest {
 
   public static final String TIDB_HOST = "TIDB_HOST";
@@ -160,7 +163,7 @@ public class FlinkTest {
     Map<String, String> properties = new HashMap<>();
     properties.put(DATABASE_URL,
         String.format(
-            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false",
+            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2",
             tidbHost, tidbPort));
     properties.put(USERNAME, tidbUser);
     properties.put(PASSWORD, tidbPassword);

--- a/flink/flink-1.12/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
+++ b/flink/flink-1.12/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
@@ -9,6 +9,7 @@ import static io.tidb.bigdata.tidb.ClientConfig.TIDB_WRITE_MODE;
 import static io.tidb.bigdata.tidb.ClientConfig.USERNAME;
 import static java.lang.String.format;
 
+import io.tidb.bigdata.test.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,7 +27,9 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class FlinkTest {
 
   public static final String TIDB_HOST = "TIDB_HOST";
@@ -170,7 +173,7 @@ public class FlinkTest {
     Map<String, String> properties = new HashMap<>();
     properties.put(DATABASE_URL,
         String.format(
-            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false",
+            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2",
             tidbHost, tidbPort));
     properties.put(USERNAME, tidbUser);
     properties.put(PASSWORD, tidbPassword);

--- a/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
+++ b/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTest.java
@@ -12,6 +12,7 @@ import static java.lang.String.format;
 
 import io.tidb.bigdata.flink.connector.catalog.TiDBCatalog;
 import io.tidb.bigdata.flink.connector.source.TiDBOptions;
+import io.tidb.bigdata.test.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,7 +30,9 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class FlinkTest {
 
   public static final String TIDB_HOST = "TIDB_HOST";
@@ -173,7 +176,7 @@ public class FlinkTest {
     Map<String, String> properties = new HashMap<>();
     properties.put(DATABASE_URL,
         String.format(
-            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false",
+            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2",
             tidbHost, tidbPort));
     properties.put(USERNAME, tidbUser);
     properties.put(PASSWORD, tidbPassword);

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -30,6 +30,15 @@
     <module>flink-1.13</module>
   </modules>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <profiles>
     <profile>
       <id>local-debug</id>

--- a/jdbc/driver/src/test/java/io/tidb/bigdata/jdbc/TiDBDriverTest.java
+++ b/jdbc/driver/src/test/java/io/tidb/bigdata/jdbc/TiDBDriverTest.java
@@ -19,6 +19,7 @@ package io.tidb.bigdata.jdbc;
 import io.tidb.bigdata.jdbc.impl.DiscovererImpl;
 import io.tidb.bigdata.jdbc.impl.RandomShuffleUrlMapper;
 import io.tidb.bigdata.jdbc.impl.RoundRobinUrlMapper;
+import io.tidb.bigdata.test.IntegrationTest;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -28,7 +29,9 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class TiDBDriverTest {
 
   public static final String JDBC_DRIVER = "io.tidb.bigdata.jdbc.TiDBDriver";

--- a/jdbc/mariadb-compat/src/test/java/org/mariadb/jdbc/MariaDBDriverTest.java
+++ b/jdbc/mariadb-compat/src/test/java/org/mariadb/jdbc/MariaDBDriverTest.java
@@ -16,18 +16,14 @@
 
 package org.mariadb.jdbc;
 
-import io.tidb.bigdata.jdbc.impl.RandomShuffleUrlMapper;
-import io.tidb.bigdata.jdbc.impl.DiscovererImpl;
-import io.tidb.bigdata.jdbc.impl.RoundRobinUrlMapper;
+import io.tidb.bigdata.test.IntegrationTest;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class MariaDBDriverTest {
 
   public static final String JDBC_DRIVER = "org.mariadb.jdbc.Driver";

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,4 +19,14 @@
     <module>driver</module>
     <module>mariadb-compat</module>
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
+++ b/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
@@ -18,6 +18,7 @@ package io.tidb.bigdata.mapreduce.tidb;
 
 import static java.lang.String.format;
 
+import io.tidb.bigdata.test.IntegrationTest;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.ColumnHandleInternal;
@@ -44,7 +45,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class MapReduceTest {
   public static final String TIDB_HOST = "TIDB_HOST";
 
@@ -180,18 +183,18 @@ public class MapReduceTest {
   public ClientSession getSingleConnection() {
 
     Map<String, String> properties = new HashMap<>();
-    properties.put(ClientConfig.DATABASE_URL, String.format("jdbc:mysql://%s:%s/test", tidbHost, tidbPort));
+    properties.put(ClientConfig.DATABASE_URL, String.format("jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2", tidbHost, tidbPort));
     properties.put(ClientConfig.USERNAME, tidbUser);
     properties.put(ClientConfig.PASSWORD, tidbPassword);
 
-    return ClientSession.createWithSingleConnection(new ClientConfig(properties));
+    return ClientSession.create(new ClientConfig(properties));
   }
 
   @Test
   public void testReadRecords() throws Exception {
 
     try (Connection connection = DriverManager.getConnection(
-        String.format("jdbc:mysql://%s:%s/test", tidbHost, tidbPort), tidbUser, tidbPassword)) {
+        String.format("jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2", tidbHost, tidbPort), tidbUser, tidbPassword)) {
       doUpdateSql(connection, getCreateDatabaseSql(DATABASE_NAME));
       doUpdateSql(connection, getDropTableSql(TABLE_NAME));
       doUpdateSql(connection, getCreateTableSql(TABLE_NAME));
@@ -212,7 +215,7 @@ public class MapReduceTest {
               .collect(Collectors.toList()),
           Optional.empty(),
           Optional.empty(),
-          Integer.MAX_VALUE);
+          Optional.of(Integer.MAX_VALUE));
       RecordCursorInternal cursor = recordSetInternal.cursor();
       cursor.advanceNextPosition();
       TiDBResultSet tiDBResultSet = new TiDBResultSet(cursor.fieldCount(), null);

--- a/mapreduce/pom.xml
+++ b/mapreduce/pom.xml
@@ -30,4 +30,13 @@
     </profile>
   </profiles>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit47</artifactId>
+              <version>${failsafe.version}</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <parallel>suites</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
     <gpg.skip>true</gpg.skip>
     <javadoc.skip>true</javadoc.skip>
     <mysql.driver.scope>test</mysql.driver.scope>
+    <failsafe.version>3.0.0-M3</failsafe.version>
+    <skipIntegrationTests>false</skipIntegrationTests>
   </properties>
 
   <repositories>
@@ -165,6 +167,7 @@
     <module>mapreduce</module>
     <module>trino</module>
     <module>hive</module>
+    <module>test</module>
   </modules>
 
   <build>
@@ -177,8 +180,45 @@
             <parallel>suites</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
             <forkMode>always</forkMode>
+            <!-- Skip the Integration tests as part of surefire run -->
+            <excludedGroups>io.tidb.bigdata.test.IntegrationTest</excludedGroups>
           </configuration>
           <version>3.0.0-M3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${failsafe.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit47</artifactId>
+              <version>${failsafe.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <skip>${skipIntegrationTests}</skip>
+            <groups>io.tidb.bigdata.test.IntegrationTest</groups>
+            <includes>
+              <include>**/*.java</include>
+            </includes>
+          </configuration>
+          <executions>
+            <execution>
+              <id>integration</id>
+              <phase>integration-test</phase>
+              <goals>
+                <goal>integration-test</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>verify</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/prestodb/pom.xml
+++ b/prestodb/pom.xml
@@ -63,6 +63,12 @@
       <version>${dep.prestodb.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/prestodb/pom.xml
+++ b/prestodb/pom.xml
@@ -104,10 +104,6 @@
         <version>2.4.1</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.2.1</version>
         <configuration>

--- a/prestodb/src/test/java/io/tidb/bigdata/prestodb/ConfigUtils.java
+++ b/prestodb/src/test/java/io/tidb/bigdata/prestodb/ConfigUtils.java
@@ -41,7 +41,7 @@ public class ConfigUtils {
 
   public static Map<String, String> getProperties() {
     return ImmutableMap.<String, String>builder()
-        .put(DATABASE_URL, String.format("jdbc:mysql://%s:%s/test", tidbHost, tidbPort))
+        .put(DATABASE_URL, String.format("jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2", tidbHost, tidbPort))
         .put(USERNAME, tidbUser)
         .put(PASSWORD, tidbPassword)
         .build();

--- a/prestodb/src/test/java/io/tidb/bigdata/prestodb/ConnectorsPluginTest.java
+++ b/prestodb/src/test/java/io/tidb/bigdata/prestodb/ConnectorsPluginTest.java
@@ -5,8 +5,11 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.testing.TestingConnectorContext;
+import io.tidb.bigdata.test.IntegrationTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class ConnectorsPluginTest {
 
   @Test

--- a/prestodb/src/test/java/io/tidb/bigdata/prestodb/PrestoTest.java
+++ b/prestodb/src/test/java/io/tidb/bigdata/prestodb/PrestoTest.java
@@ -4,9 +4,12 @@ import static com.facebook.presto.testing.MaterializedResult.DEFAULT_PRECISION;
 
 import com.facebook.presto.testing.MaterializedRow;
 import com.google.common.collect.ImmutableList;
+import io.tidb.bigdata.test.IntegrationTest;
 import java.util.List;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class PrestoTest {
 
   private final TiDBQueryRunner tiDBQueryRunner = new TiDBQueryRunner();

--- a/prestosql/pom.xml
+++ b/prestosql/pom.xml
@@ -99,10 +99,6 @@
         <version>2.4.1</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.2.1</version>
         <configuration>

--- a/prestosql/pom.xml
+++ b/prestosql/pom.xml
@@ -58,6 +58,12 @@
       <version>${dep.prestosql.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/prestosql/src/test/java/io/tibigdata/prestosql/ConfigUtils.java
+++ b/prestosql/src/test/java/io/tibigdata/prestosql/ConfigUtils.java
@@ -41,7 +41,7 @@ public class ConfigUtils {
 
   public static Map<String, String> getProperties() {
     return ImmutableMap.<String, String>builder()
-        .put(DATABASE_URL, String.format("jdbc:mysql://%s:%s/test", tidbHost, tidbPort))
+        .put(DATABASE_URL, String.format("jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2", tidbHost, tidbPort))
         .put(USERNAME, tidbUser)
         .put(PASSWORD, tidbPassword)
         .build();

--- a/prestosql/src/test/java/io/tibigdata/prestosql/ConnectorsPluginTest.java
+++ b/prestosql/src/test/java/io/tibigdata/prestosql/ConnectorsPluginTest.java
@@ -6,9 +6,11 @@ import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 import io.prestosql.testing.TestingConnectorContext;
 import io.tidb.bigdata.prestosql.ConnectorsPlugin;
+import io.tidb.bigdata.test.IntegrationTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-
+@Category(IntegrationTest.class)
 public class ConnectorsPluginTest {
 
   @Test

--- a/prestosql/src/test/java/io/tibigdata/prestosql/PrestoTest.java
+++ b/prestosql/src/test/java/io/tibigdata/prestosql/PrestoTest.java
@@ -4,9 +4,12 @@ import static io.prestosql.testing.MaterializedResult.DEFAULT_PRECISION;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.testing.MaterializedRow;
+import io.tidb.bigdata.test.IntegrationTest;
 import java.util.List;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class PrestoTest {
 
   private final TiDBQueryRunner tiDBQueryRunner = new TiDBQueryRunner();

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>bigdata</artifactId>
+    <groupId>io.tidb</groupId>
+    <version>0.0.5-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>test</artifactId>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+  </properties>
+
+</project>

--- a/test/src/main/java/io/tidb/bigdata/test/IntegrationTest.java
+++ b/test/src/main/java/io/tidb/bigdata/test/IntegrationTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.test;
+
+public interface IntegrationTest {
+
+}

--- a/ticdc/pom.xml
+++ b/ticdc/pom.xml
@@ -45,7 +45,14 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <version>${dep.jackson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
   <modelVersion>4.0.0</modelVersion>
   <name>TiBigData Project CDC Decoder</name>
   <packaging>jar</packaging>

--- a/tidb/pom.xml
+++ b/tidb/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>HikariCP</artifactId>
       <version>${dep.HikariCP.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/ConfigUtils.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/ConfigUtils.java
@@ -61,7 +61,7 @@ public class ConfigUtils {
     Map<String, String> properties = new HashMap<>();
     properties.put(DATABASE_URL,
         String.format(
-            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false",
+            "jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2",
             tidbHost, tidbPort));
     properties.put(USERNAME, tidbUser);
     properties.put(PASSWORD, tidbPassword);

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/JdbcConnectionProviderFactoryTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/JdbcConnectionProviderFactoryTest.java
@@ -16,12 +16,15 @@
 
 package io.tidb.bigdata.tidb;
 
+import io.tidb.bigdata.test.IntegrationTest;
 import io.tidb.bigdata.tidb.JdbcConnectionProviderFactory.BasicJdbcConnectionProvider;
 import io.tidb.bigdata.tidb.JdbcConnectionProviderFactory.HikariDataSourceJdbcConnectionProvider;
 import io.tidb.bigdata.tidb.JdbcConnectionProviderFactory.JdbcConnectionProvider;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class JdbcConnectionProviderFactoryTest {
 
   @Test

--- a/trino/pom.xml
+++ b/trino/pom.xml
@@ -99,10 +99,6 @@
         <version>2.4.1</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.2.1</version>
         <configuration>

--- a/trino/pom.xml
+++ b/trino/pom.xml
@@ -58,6 +58,12 @@
       <version>${dep.trino.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.tidb</groupId>
+      <artifactId>test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/trino/src/test/java/io/tibigdata/trino/ConfigUtils.java
+++ b/trino/src/test/java/io/tibigdata/trino/ConfigUtils.java
@@ -41,7 +41,7 @@ public class ConfigUtils {
 
   public static Map<String, String> getProperties() {
     return ImmutableMap.<String, String>builder()
-        .put(DATABASE_URL, String.format("jdbc:mysql://%s:%s/test", tidbHost, tidbPort))
+        .put(DATABASE_URL, String.format("jdbc:mysql://%s:%s/test?serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=CONVERT_TO_NULL&tinyInt1isBit=false&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2", tidbHost, tidbPort))
         .put(USERNAME, tidbUser)
         .put(PASSWORD, tidbPassword)
         .build();

--- a/trino/src/test/java/io/tibigdata/trino/ConnectorsPluginTest.java
+++ b/trino/src/test/java/io/tibigdata/trino/ConnectorsPluginTest.java
@@ -2,13 +2,15 @@ package io.tibigdata.trino;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 
+import io.tidb.bigdata.test.IntegrationTest;
 import io.tidb.bigdata.trino.ConnectorsPlugin;
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-
+@Category(IntegrationTest.class)
 public class ConnectorsPluginTest {
 
   @Test

--- a/trino/src/test/java/io/tibigdata/trino/PrestoTest.java
+++ b/trino/src/test/java/io/tibigdata/trino/PrestoTest.java
@@ -3,10 +3,13 @@ package io.tibigdata.trino;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
 
 import com.google.common.collect.ImmutableList;
+import io.tidb.bigdata.test.IntegrationTest;
 import io.trino.testing.MaterializedRow;
 import java.util.List;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(IntegrationTest.class)
 public class PrestoTest {
 
   private final TiDBQueryRunner tiDBQueryRunner = new TiDBQueryRunner();


### PR DESCRIPTION
## What problem does this PR solve?
- Use Junit Category to distinguish unit tests and integration tests so that we can run tests separately.

## Related changes
- modify readme about run tests and how to write tests
- modify ci to run unit tests and integration tests separately.