### PR TITLE
ADD configuration to print the full exception stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,8 @@
             </dependency>
           </dependencies>
           <configuration>
+            <trimStackTrace>false</trimStackTrace>
+            <useFile>false</useFile>
             <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
             <parallel>suites</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
@@ -205,6 +207,8 @@
             </dependency>
           </dependencies>
           <configuration>
+            <trimStackTrace>false</trimStackTrace>
+            <useFile>false</useFile>
             <skip>${skipIntegrationTests}</skip>
             <groups>io.tidb.bigdata.test.IntegrationTest</groups>
             <includes>


### PR DESCRIPTION
## What is the purpose of the change

The output of the exception stack is not detailed enough, need to print the whole stack. https://stackoverflow.com/questions/2928548/make-mavens-surefire-show-stacktrace-in-console

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/17768378/172125811-2892e14b-d68b-49b8-9e29-356845654b22.png">


## Brief change log

-  set maven-surefire-plugin `trimStackTrace` and `useFile` to false
-  set maven-failsafe-plugin `trimStackTrace` and `useFile` to false

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. The result turns out to be

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/17768378/172126202-41a31976-ea4b-4a98-99d6-2d6907215c1b.png">

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The runtime per-record code paths (performance sensitive): (no)

## Documentation

- Does this pull request introduce a new feature? (no)
