### PR TITLE
[Issue-199] Fix upsert bug

### DIFF
--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/TiDBCatalog.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/TiDBCatalog.java
@@ -437,6 +437,10 @@ public class TiDBCatalog extends AbstractCatalog {
     return getClientSession().queryTableCount(databaseName, tableName);
   }
 
+  public int queryIndexCount(String databaseName, String tableName, String indexName) {
+    return getClientSession().queryIndexCount(databaseName, tableName, indexName);
+  }
+
   private ClientSession getClientSession() {
     if (clientSession.isPresent()) {
       return clientSession.get();

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTestBase.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTestBase.java
@@ -24,13 +24,19 @@ import static io.tidb.bigdata.flink.connector.TiDBOptions.SinkTransaction.MINIBA
 import static io.tidb.bigdata.test.ConfigUtils.defaultProperties;
 import static java.lang.String.format;
 
+import com.google.common.collect.Lists;
 import io.tidb.bigdata.flink.connector.TiDBCatalog;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.Assert;
 import org.junit.ClassRule;
 
@@ -174,5 +180,17 @@ public abstract class FlinkTestBase {
             DATABASE_NAME, tableName, rowCount * 8, 100);
     tiDBCatalog.sqlUpdate(splitRegionSql);
     Assert.assertEquals(rowCount, tiDBCatalog.queryTableCount(DATABASE_NAME, tableName));
+  }
+
+  protected static void checkRowResult(
+      TableEnvironment tableEnvironment, List<String> expected, String dstTable) {
+    Table table =
+        tableEnvironment.sqlQuery(
+            String.format("SELECT * FROM `tidb`.`%s`.`%s`", DATABASE_NAME, dstTable));
+    CloseableIterator<Row> resultIterator = table.execute().collect();
+    List<String> actualResult =
+        Lists.newArrayList(resultIterator).stream().map(Row::toString).collect(Collectors.toList());
+
+    Assert.assertEquals(expected, actualResult);
   }
 }

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTestBase.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTestBase.java
@@ -96,12 +96,17 @@ public abstract class FlinkTestBase {
           + "    unique key(c1)\n"
           + ")";
 
-  protected TableEnvironment getTableEnvironment() {
+  protected static TableEnvironment getBatchTableEnvironment() {
     EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
     return TableEnvironment.create(settings);
   }
 
-  protected StreamTableEnvironment getBatchModeStreamTableEnvironment() {
+  protected static TableEnvironment getStreamingTableEnvironment() {
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+    return TableEnvironment.create(settings);
+  }
+
+  protected static StreamTableEnvironment getBatchModeStreamTableEnvironment() {
     EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(env, settings);

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/SqlHintTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/SqlHintTest.java
@@ -47,7 +47,7 @@ public class SqlHintTest extends FlinkTestBase {
     generateData(srcTable, rowCount);
     dstTable = RandomUtils.randomString();
 
-    TableEnvironment tableEnvironment = getTableEnvironment();
+    TableEnvironment tableEnvironment = getBatchTableEnvironment();
 
     Map<String, String> properties = defaultProperties();
     properties.put(SINK_IMPL.key(), TIKV.name());

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/catalog/TiDBCatalogTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/catalog/TiDBCatalogTest.java
@@ -181,7 +181,7 @@ public class TiDBCatalogTest extends FlinkTestBase {
   private Row runByCatalog(Map<String, String> properties, String resultSql, String tableName)
       throws Exception {
     // env
-    TableEnvironment tableEnvironment = getTableEnvironment();
+    TableEnvironment tableEnvironment = getBatchTableEnvironment();
     // create test database and table
     TiDBCatalog tiDBCatalog = new TiDBCatalog(properties);
     tiDBCatalog.open();

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.tidb.bigdata.flink.tidb.sink;
 
 import static io.tidb.bigdata.flink.connector.TiDBOptions.DEDUPLICATE;

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
@@ -20,21 +20,28 @@ import static io.tidb.bigdata.flink.connector.TiDBOptions.DEDUPLICATE;
 import static io.tidb.bigdata.flink.connector.TiDBOptions.SINK_IMPL;
 import static io.tidb.bigdata.flink.connector.TiDBOptions.SINK_TRANSACTION;
 import static io.tidb.bigdata.flink.connector.TiDBOptions.SinkImpl.TIKV;
-import static io.tidb.bigdata.flink.connector.TiDBOptions.SinkTransaction.MINIBATCH;
 import static io.tidb.bigdata.flink.connector.TiDBOptions.WRITE_MODE;
 import static io.tidb.bigdata.test.ConfigUtils.defaultProperties;
 
 import com.google.common.collect.Lists;
 import io.tidb.bigdata.flink.connector.TiDBCatalog;
+import io.tidb.bigdata.flink.connector.TiDBOptions.SinkTransaction;
 import io.tidb.bigdata.flink.tidb.FlinkTestBase;
+import io.tidb.bigdata.test.IntegrationTest;
 import io.tidb.bigdata.test.RandomUtils;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import java.util.function.Supplier;
+import org.apache.flink.table.api.TableEnvironment;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
 
+@Category(IntegrationTest.class)
+@RunWith(org.junit.runners.Parameterized.class)
 public class TiKVUpsertTest extends FlinkTestBase {
 
   private static final String TABLE =
@@ -45,17 +52,49 @@ public class TiKVUpsertTest extends FlinkTestBase {
           + "  PRIMARY KEY (`id`) USING BTREE\n"
           + ")";
 
+  private final SinkTransaction transaction;
+  private final Supplier<TableEnvironment> tableEnvironmentSupplier;
+  private final String mode;
+
+  public TiKVUpsertTest(
+      SinkTransaction transaction,
+      Supplier<TableEnvironment> tableEnvironmentSupplier,
+      String mode) {
+    this.transaction = transaction;
+    this.tableEnvironmentSupplier = tableEnvironmentSupplier;
+    this.mode = mode;
+  }
+
+  @Parameters(name = "{index}: mode={2}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {
+            SinkTransaction.MINIBATCH,
+            (Supplier<TableEnvironment>) FlinkTestBase::getBatchTableEnvironment,
+            "Batch"
+          },
+          {
+            SinkTransaction.GLOBAL,
+            (Supplier<TableEnvironment>) FlinkTestBase::getBatchTableEnvironment,
+            "Batch"
+          },
+          {
+            SinkTransaction.MINIBATCH,
+            (Supplier<TableEnvironment>) FlinkTestBase::getStreamingTableEnvironment,
+            "Streaming"
+          },
+        });
+  }
+
   @Test
-  public void testMiniBatchTransaction() throws Exception {
+  public void testUpsert() throws Exception {
     String dstTable = RandomUtils.randomString();
-    EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
-    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-    env.setParallelism(1);
-    StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(env, settings);
+    TableEnvironment tableEnvironment = tableEnvironmentSupplier.get();
 
     Map<String, String> properties = defaultProperties();
     properties.put(SINK_IMPL.key(), TIKV.name());
-    properties.put(SINK_TRANSACTION.key(), MINIBATCH.name());
+    properties.put(SINK_TRANSACTION.key(), transaction.name());
     properties.put(DEDUPLICATE.key(), "true");
     properties.put(WRITE_MODE.key(), "upsert");
 
@@ -64,6 +103,8 @@ public class TiKVUpsertTest extends FlinkTestBase {
     tableEnvironment.sqlUpdate(
         String.format(
             "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'before')", DATABASE_NAME, dstTable));
+    tableEnvironment.execute("test");
+
     tableEnvironment.sqlUpdate(
         String.format(
             "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'after')", DATABASE_NAME, dstTable));

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
@@ -63,7 +63,7 @@ public class TiKVUpsertTest extends FlinkTestBase {
     this.mode = mode;
   }
 
-  @Parameters(name = "{index}: mode={2}")
+  @Parameters(name = "{index}: transaction={0} mode={2}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
@@ -1,0 +1,59 @@
+package io.tidb.bigdata.flink.tidb.sink;
+
+import static io.tidb.bigdata.flink.connector.TiDBOptions.DEDUPLICATE;
+import static io.tidb.bigdata.flink.connector.TiDBOptions.SINK_IMPL;
+import static io.tidb.bigdata.flink.connector.TiDBOptions.SINK_TRANSACTION;
+import static io.tidb.bigdata.flink.connector.TiDBOptions.SinkImpl.TIKV;
+import static io.tidb.bigdata.flink.connector.TiDBOptions.SinkTransaction.MINIBATCH;
+import static io.tidb.bigdata.flink.connector.TiDBOptions.WRITE_MODE;
+import static io.tidb.bigdata.test.ConfigUtils.defaultProperties;
+
+import com.google.common.collect.Lists;
+import io.tidb.bigdata.flink.connector.TiDBCatalog;
+import io.tidb.bigdata.flink.tidb.FlinkTestBase;
+import io.tidb.bigdata.test.RandomUtils;
+import java.util.Map;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TiKVUpsertTest extends FlinkTestBase {
+
+  private static final String TABLE =
+      "CREATE TABLE IF NOT EXISTS `%s`.`%s`\n"
+          + "("
+          + "  `id` bigint(20) NOT NULL,\n"
+          + "  `name` varchar(255) NULL DEFAULT NULL,\n"
+          + "  PRIMARY KEY (`id`) USING BTREE\n"
+          + ")";
+
+  @Test
+  public void testMiniBatchTransaction() throws Exception {
+    String dstTable = RandomUtils.randomString();
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(env, settings);
+
+    Map<String, String> properties = defaultProperties();
+    properties.put(SINK_IMPL.key(), TIKV.name());
+    properties.put(SINK_TRANSACTION.key(), MINIBATCH.name());
+    properties.put(DEDUPLICATE.key(), "true");
+    properties.put(WRITE_MODE.key(), "upsert");
+
+    TiDBCatalog tiDBCatalog = initTiDBCatalog(dstTable, TABLE, tableEnvironment, properties);
+
+    tableEnvironment.sqlUpdate(
+        String.format(
+            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'before')", DATABASE_NAME, dstTable));
+    tableEnvironment.sqlUpdate(
+        String.format(
+            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'after')", DATABASE_NAME, dstTable));
+    tableEnvironment.execute("test");
+
+    Assert.assertEquals(1, tiDBCatalog.queryTableCount(DATABASE_NAME, dstTable));
+    checkRowResult(tableEnvironment, Lists.newArrayList("+I[1, after]"), dstTable);
+  }
+}

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.flink.table.api.TableEnvironment;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -102,15 +101,14 @@ public class TiKVUpsertTest extends FlinkTestBase {
 
     tableEnvironment.sqlUpdate(
         String.format(
-            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'before')", DATABASE_NAME, dstTable));
+            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'before'), (2, 'before')", DATABASE_NAME, dstTable));
     tableEnvironment.execute("test");
 
     tableEnvironment.sqlUpdate(
         String.format(
-            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'after')", DATABASE_NAME, dstTable));
+            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'after'), (2, 'after')", DATABASE_NAME, dstTable));
     tableEnvironment.execute("test");
 
-    Assert.assertEquals(1, tiDBCatalog.queryTableCount(DATABASE_NAME, dstTable));
-    checkRowResult(tableEnvironment, Lists.newArrayList("+I[1, after]"), dstTable);
+    checkRowResult(tableEnvironment, Lists.newArrayList("+I[1, after]", "+I[2, after]"), dstTable);
   }
 }

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVUpsertTest.java
@@ -24,7 +24,6 @@ import static io.tidb.bigdata.flink.connector.TiDBOptions.WRITE_MODE;
 import static io.tidb.bigdata.test.ConfigUtils.defaultProperties;
 
 import com.google.common.collect.Lists;
-import io.tidb.bigdata.flink.connector.TiDBCatalog;
 import io.tidb.bigdata.flink.connector.TiDBOptions.SinkTransaction;
 import io.tidb.bigdata.flink.tidb.FlinkTestBase;
 import io.tidb.bigdata.test.IntegrationTest;
@@ -97,16 +96,18 @@ public class TiKVUpsertTest extends FlinkTestBase {
     properties.put(DEDUPLICATE.key(), "true");
     properties.put(WRITE_MODE.key(), "upsert");
 
-    TiDBCatalog tiDBCatalog = initTiDBCatalog(dstTable, TABLE, tableEnvironment, properties);
+    initTiDBCatalog(dstTable, TABLE, tableEnvironment, properties);
 
     tableEnvironment.sqlUpdate(
         String.format(
-            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'before'), (2, 'before')", DATABASE_NAME, dstTable));
+            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'before'), (2, 'before')",
+            DATABASE_NAME, dstTable));
     tableEnvironment.execute("test");
 
     tableEnvironment.sqlUpdate(
         String.format(
-            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'after'), (2, 'after')", DATABASE_NAME, dstTable));
+            "INSERT INTO `tidb`.`%s`.`%s` " + "VALUES(1, 'after'), (2, 'after')",
+            DATABASE_NAME, dstTable));
     tableEnvironment.execute("test");
 
     checkRowResult(tableEnvironment, Lists.newArrayList("+I[1, after]", "+I[2, after]"), dstTable);

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/source/TIKVSourceTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/source/TIKVSourceTest.java
@@ -105,7 +105,7 @@ public class TIKVSourceTest extends FlinkTestBase {
       }
 
       // read by version
-      TableEnvironment tableEnvironment = getTableEnvironment();
+      TableEnvironment tableEnvironment = getBatchTableEnvironment();
       properties.put("type", "tidb");
       String createCatalogSql =
           format("CREATE CATALOG `tidb` WITH ( %s )", TableUtils.toSqlProperties(properties));

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
@@ -349,6 +349,21 @@ public final class ClientSession implements AutoCloseable {
     }
   }
 
+  public int queryIndexCount(String databaseName, String tableName, String indexName) {
+    try (Connection connection = jdbcConnectionProvider.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery(
+                format(
+                    "SELECT COUNT(`%s`) as c FROM `%s`.`%s`",
+                    indexName, databaseName, tableName))) {
+      resultSet.next();
+      return resultSet.getInt("c");
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   public boolean supportClusteredIndex() {
     try (Connection connection = jdbcConnectionProvider.getConnection();
         Statement statement = connection.createStatement();

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/codec/TiDBEncodeHelper.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/codec/TiDBEncodeHelper.java
@@ -339,7 +339,7 @@ public class TiDBEncodeHelper implements AutoCloseable {
 
     // if the key needs to be updated, then the deletion pair need to be removed and keep
     // the update pair. Otherwise, the execution order can't be guaranteed, which may cause
-    // a problem when the update pair is executed first.
+    // the deletion of the row when the update pair is executed first and deletion pair second.
     for (BytePairWrapper keyValue : keyValues) {
       conflictRowDeletionPairs.remove(ByteBuffer.wrap(keyValue.getKey()));
     }

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/codec/TiDBEncodeHelper.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/codec/TiDBEncodeHelper.java
@@ -242,8 +242,20 @@ public class TiDBEncodeHelper implements AutoCloseable {
   }
 
   /**
-   * Generate the key-value pair conflicted with the given row. - unique index conflict - key:
-   * encoded index key - value: empty - primary index conflict - key: encoded row key - value: empty
+   * Generate the key-value pair conflicted with the given row. <br>
+   *
+   * <ul>
+   *   <li>- unique index conflict
+   *       <ul>
+   *         <li>- key: encoded index key
+   *         <li>- value: empty
+   *       </ul>
+   *   <li>- primary index conflict
+   *       <ul>
+   *         <li>- key: encoded row key
+   *         <li>- value: empty
+   *       </ul>
+   * </ul>
    */
   private Map<ByteBuffer, BytePairWrapper> fetchConflictedRowDeletionPairs(
       Row tiRow, Handle handle) {


### PR DESCRIPTION
## What is the purpose of the change

close #199

When BytePair has the same key, it seems like the executive order is not the same as the list order.
When upserting, there are two pairs, one is for the delete(value='') and another is for the insert(value='newValue').
In this situation, we should remove the delete and keep the insert(since it's a KV store, we can update the value).

## Brief change log

- cache the delete pairs for the row, remove if there is an insert pair that has the same key.

## Verifying this change

This change added tests and can be verified as follows:
- `TiKVUpsertTest#testUpsert()`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The runtime per-record code paths (performance sensitive): (no)

## Documentation

- Does this pull request introduce a new feature? (no)
