### PR TITLE
Set maven not to display download progress

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -6,18 +6,18 @@ set -euo pipefail
 # see maven plugin
 # git submodule update --init --recursive
 
-mvn clean compile test -am -pl ticdc
-mvn clean compile test -am -pl flink/flink-1.11
-mvn clean compile test -am -pl flink/flink-1.12
-mvn clean compile test -am -pl flink/flink-1.13
-mvn clean compile test -am -pl flink/flink-1.14
-mvn clean compile test -am -pl mapreduce/mapreduce-base
-mvn clean compile test -am -pl prestodb
-mvn clean compile test -am -pl jdbc
-mvn clean compile test -am -pl hive/hive-2.2.0
-mvn clean compile test -am -pl hive/hive-2.3.6
-mvn clean compile test -am -pl hive/hive-3.1.2
+mvn clean compile test -B -am -pl ticdc
+mvn clean compile test -B -am -pl flink/flink-1.11
+mvn clean compile test -B -am -pl flink/flink-1.12
+mvn clean compile test -B -am -pl flink/flink-1.13
+mvn clean compile test -B -am -pl flink/flink-1.14
+mvn clean compile test -B -am -pl mapreduce/mapreduce-base
+mvn clean compile test -B -am -pl prestodb
+mvn clean compile test -B -am -pl jdbc
+mvn clean compile test -B -am -pl hive/hive-2.2.0
+mvn clean compile test -B -am -pl hive/hive-2.3.6
+mvn clean compile test -B -am -pl hive/hive-3.1.2
 
 export JAVA_HOME=/home/jenkins/agent/lib/jdk-11.0.12
-mvn clean compile test -am -pl prestosql
-mvn clean compile test -am -pl trino
+mvn clean compile test -B -am -pl prestosql
+mvn clean compile test -B -am -pl trino

--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -172,7 +172,7 @@ def call(ghprbActualCommit, ghprbPullId, ghprbPullTitle, ghprbPullLink, ghprbPul
                                         export TIDB_USER="root"
                                         export TIDB_PASSWORD=""
                                         $java_home
-                                        mvn clean test-compile failsafe:integration-test failsafe:verify -am -pl ${module}
+                                        mvn clean test-compile failsafe:integration-test failsafe:verify -B -am -pl ${module}
                                     """
                                 }
                             } catch (err) {


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

## Brief change log

*(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API: (yes / no)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
