### PR TITLE
[DNM] reproduce bug

### DIFF
--- a/flink/flink-1.14/pom.xml
+++ b/flink/flink-1.14/pom.xml
@@ -94,6 +94,12 @@
       <artifactId>mysql-connector-java</artifactId>
       <version>${dep.mysql.jdbc.version}</version>
       <scope>${flink.scope}</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/sink/operator/TiDBWriteOperator.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/sink/operator/TiDBWriteOperator.java
@@ -79,8 +79,8 @@ public abstract class TiDBWriteOperator extends AbstractStreamOperator<Void>
             session, databaseName, tableName, sinkOptions.getRowIdAllocatorStep());
 
     // Start operator orderly in order to avoid rowID allocation conflict.
-    Thread.sleep(
-        sinkOptions.getTaskStartInterval() * this.getRuntimeContext().getIndexOfThisSubtask());
+//    Thread.sleep(
+//        sinkOptions.getTaskStartInterval() * this.getRuntimeContext().getIndexOfThisSubtask());
     openInternal();
   }
 

--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/sink/operator/TiDBWriteOperator.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/sink/operator/TiDBWriteOperator.java
@@ -79,8 +79,9 @@ public abstract class TiDBWriteOperator extends AbstractStreamOperator<Void>
             session, databaseName, tableName, sinkOptions.getRowIdAllocatorStep());
 
     // Start operator orderly in order to avoid rowID allocation conflict.
-//    Thread.sleep(
-//        sinkOptions.getTaskStartInterval() * this.getRuntimeContext().getIndexOfThisSubtask());
+    //    Thread.sleep(
+    //        sinkOptions.getTaskStartInterval() *
+    // this.getRuntimeContext().getIndexOfThisSubtask());
     openInternal();
   }
 

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTestBase.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/FlinkTestBase.java
@@ -132,7 +132,7 @@ public abstract class FlinkTestBase {
     Map<String, String> properties = defaultProperties();
     properties.put(SINK_IMPL.key(), TIKV.name());
     properties.put(SINK_TRANSACTION.key(), MINIBATCH.name());
-    properties.put(ROW_ID_ALLOCATOR_STEP.key(), Integer.toString(10000));
+    properties.put(ROW_ID_ALLOCATOR_STEP.key(), Integer.toString(100));
     TiDBCatalog tiDBCatalog = new TiDBCatalog(properties);
     tableEnvironment.registerCatalog("tidb", tiDBCatalog);
     String dropTableSql = format("DROP TABLE IF EXISTS `%s`.`%s`", DATABASE_NAME, tableName);

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVSinkBatchModeTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVSinkBatchModeTest.java
@@ -113,10 +113,8 @@ public class TiKVSinkBatchModeTest extends FlinkTestBase {
         .sqlUpdate(String.format("DROP TABLE IF EXISTS `%s`.`%s`", DATABASE_NAME, dstTable));
   }
 
-
   public static void main(String[] args) {
     KeyError build = KeyError.newBuilder().setConflict(WriteConflict.getDefaultInstance()).build();
     System.out.println(build.toString());
   }
-
 }

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVSinkBatchModeTest.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/sink/TiKVSinkBatchModeTest.java
@@ -39,6 +39,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
+import org.tikv.kvproto.Kvrpcpb.KeyError;
+import org.tikv.kvproto.Kvrpcpb.WriteConflict;
 
 @Category(IntegrationTest.class)
 @RunWith(org.junit.runners.Parameterized.class)
@@ -110,4 +112,11 @@ public class TiKVSinkBatchModeTest extends FlinkTestBase {
         .getClientSession()
         .sqlUpdate(String.format("DROP TABLE IF EXISTS `%s`.`%s`", DATABASE_NAME, dstTable));
   }
+
+
+  public static void main(String[] args) {
+    KeyError build = KeyError.newBuilder().setConflict(WriteConflict.getDefaultInstance()).build();
+    System.out.println(build.toString());
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
       <artifactId>mysql-connector-java</artifactId>
       <version>${dep.mysql.jdbc.version}</version>
       <scope>${mysql.driver.scope}</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/tidb/pom.xml
+++ b/tidb/pom.xml
@@ -55,16 +55,37 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
       <version>${grpc.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
       <version>${grpc.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.16.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>3.16.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

## Brief change log

*(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API: (yes / no)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
