### PR TITLE
Fix protobufClass.toString() cause NoClassDefFoundError or ExceptionInInitializerError

### DIFF
--- a/tidb/pom.xml
+++ b/tidb/pom.xml
@@ -133,6 +133,21 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>2.4.1</version>
+        <executions>
+          <execution>
+            <id>auto-clean</id>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>proto</directory>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
@@ -147,12 +162,6 @@
             <configuration>
               <outputDirectory>${proto.folder}</outputDirectory>
               <resources>
-                <resource>
-                  <directory>${basedir}/src/main/tipb/include</directory>
-                  <includes>
-                    <include>**/gogoproto/**</include>
-                  </includes>
-                </resource>
                 <resource>
                   <directory>${basedir}/src/main/tipb/proto</directory>
                   <filtering>true</filtering>

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/ProtobufTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/ProtobufTest.java
@@ -21,6 +21,8 @@ import org.tikv.kvproto.Kvrpcpb.KeyError;
 
 public class ProtobufTest {
 
+  // https://github.com/tidb-incubator/TiBigData/issues/217
+  // Fix protobufClass.toString() causes NoClassDefFoundError or ExceptionInInitializerError
   @Test
   public void testProtobufToString() {
     KeyError.getDefaultInstance().toString();

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/ProtobufTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/ProtobufTest.java
@@ -1,0 +1,12 @@
+package io.tidb.bigdata.tidb;
+
+import org.junit.Test;
+import org.tikv.kvproto.Kvrpcpb.KeyError;
+
+public class ProtobufTest {
+
+  @Test
+  public void testProtobufToString() {
+    KeyError.getDefaultInstance().toString();
+  }
+}

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/ProtobufTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/ProtobufTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.tidb.bigdata.tidb;
 
 import org.junit.Test;


### PR DESCRIPTION
## What is the purpose of the change

close #217
The duplicated generate class of GoGoProtos causes NoClassDefFoundError or ExceptionInInitializerError when generate class of KVprotos invoke toString()

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/17768378/174289585-9dbe22b8-14aa-4f23-88a9-695ce1d1b61f.png">

## Brief change log

- exclude the gogoproto directory in order not to generate GoGoProtos.java again since dependency `org.tikv:client-java` already has one.

## Verifying this change

This change added tests and can be verified as follows:

- `ProtobufTest#testProtobufToString()`, invoke toString method.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The runtime per-record code paths (performance sensitive): (no)

## Documentation

- Does this pull request introduce a new feature? (no)
