### PR TITLE
Optimize RowIDAllocator

### DIFF
--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/sink/operator/TiDBWriteOperator.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/sink/operator/TiDBWriteOperator.java
@@ -77,10 +77,6 @@ public abstract class TiDBWriteOperator extends AbstractStreamOperator<Void>
     this.rowIDAllocator =
         new DynamicRowIDAllocator(
             session, databaseName, tableName, sinkOptions.getRowIdAllocatorStep());
-
-    // Start operator orderly in order to avoid rowID allocation conflict.
-    Thread.sleep(
-        sinkOptions.getTaskStartInterval() * this.getRuntimeContext().getIndexOfThisSubtask());
     openInternal();
   }
 

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -80,9 +79,7 @@ public final class ClientSession implements AutoCloseable {
       ImmutableSet.of("information_schema", "metrics_schema", "performance_schema", "mysql");
 
   static final Logger LOG = LoggerFactory.getLogger(ClientSession.class);
-  private static final int ROW_ID_STEP = 30000;
-  private static final int MAX_RETRY = 0;
-  private static final long RANDOM_SLEEP_UPPER_BOUND = 0L;
+  private static final int ROW_ID_STEP_DEFAULT = 30000;
   private static final String TIDB_ENABLE_CLUSTERED_INDEX = "select @@tidb_enable_clustered_index";
 
   private final ClientConfig config;
@@ -502,57 +499,14 @@ public final class ClientSession implements AutoCloseable {
     return session;
   }
 
-  private RowIDAllocator createRowIdAllocator(
-      String databaseName,
-      String tableName,
-      int step,
-      int retry,
-      int maxRetry,
-      long randomSleepUpperBound) {
+  public RowIDAllocator createRowIdAllocator(String databaseName, String tableName, int step) {
     long dbId = catalog.getDatabase(databaseName).getId();
     TiTableInfo table = getTableMust(databaseName, tableName);
-    try {
-      LOG.info("Start create row id allocator");
-      if (randomSleepUpperBound > 0) {
-        long time = Math.abs(new Random().nextLong()) % randomSleepUpperBound + 1;
-        LOG.warn("Random sleep: {}ms to avoid tikv lock conflicts", time);
-      }
-      RowIDAllocator rowIDAllocator =
-          RowIDAllocator.create(dbId, table, session, table.isAutoIncColUnsigned(), step);
-      LOG.info(
-          "Create row id allocator success: start = {}, end = {}",
-          rowIDAllocator.getStart(),
-          rowIDAllocator.getEnd());
-      return rowIDAllocator;
-    } catch (Exception e) {
-      if (retry >= maxRetry) {
-        throw new IllegalStateException("Maximum number of retries exceeded.", e);
-      } else {
-        LOG.warn("Create RowIdAllocator failed, retry, current retry count is " + retry, e);
-        return createRowIdAllocator(
-            databaseName, tableName, step, ++retry, maxRetry, randomSleepUpperBound);
-      }
-    }
-  }
-
-  public RowIDAllocator createRowIdAllocator(
-      String databaseName, String tableName, int step, int maxRetry, long randomSleepUpperBound) {
-    return createRowIdAllocator(
-        databaseName, tableName, step, MAX_RETRY, maxRetry, randomSleepUpperBound);
-  }
-
-  public RowIDAllocator createRowIdAllocator(String databaseName, String tableName, int step) {
-    return createRowIdAllocator(databaseName, tableName, step, MAX_RETRY, RANDOM_SLEEP_UPPER_BOUND);
-  }
-
-  public RowIDAllocator createRowIdAllocator(
-      String databaseName, String tableName, int step, int maxRetry) {
-    return createRowIdAllocator(databaseName, tableName, step, maxRetry, RANDOM_SLEEP_UPPER_BOUND);
+    return RowIDAllocator.create(dbId, table, session, table.isAutoIncColUnsigned(), step);
   }
 
   public RowIDAllocator createRowIdAllocator(String databaseName, String tableName) {
-    return createRowIdAllocator(
-        databaseName, tableName, ROW_ID_STEP, MAX_RETRY, RANDOM_SLEEP_UPPER_BOUND);
+    return createRowIdAllocator(databaseName, tableName, ROW_ID_STEP_DEFAULT);
   }
 
   public boolean isClusteredIndex(String databaseName, String tableName) {

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/DynamicRowIDAllocator.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/DynamicRowIDAllocator.java
@@ -79,7 +79,7 @@ public class DynamicRowIDAllocator implements AutoCloseable {
        */
       futureTask =
           new FutureTask<>(
-              () -> session.createRowIdAllocator(databaseName, tableName, step, 3).getStart());
+              () -> session.createRowIdAllocator(databaseName, tableName, step).getStart());
       threadPool.submit(futureTask);
     }
     if (index >= step) {

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/RowIDAllocator.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/RowIDAllocator.java
@@ -151,8 +151,8 @@ public final class RowIDAllocator implements Serializable {
     } finally {
       try {
         twoPhaseCommitter.close();
-      } catch (Throwable ignored) {
-        // ignore
+      } catch (Throwable t) {
+        LOG.warn("Closing twoPhaseCommitter failed.", t);
       }
     }
   }

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/RowIDAllocator.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/RowIDAllocator.java
@@ -133,8 +133,8 @@ public final class RowIDAllocator implements Serializable {
     if (!iterator.hasNext()) {
       return;
     }
-    TwoPhaseCommitter twoPhaseCommitter = new TwoPhaseCommitter(session, timestamp.getVersion(),
-        1000L);
+    TwoPhaseCommitter twoPhaseCommitter =
+        new TwoPhaseCommitter(session, timestamp.getVersion(), 1000L);
     try {
       BytePairWrapper primaryPair = pairs.get(0);
       twoPhaseCommitter.prewritePrimaryKey(
@@ -269,9 +269,7 @@ public final class RowIDAllocator implements Serializable {
     throw new IllegalArgumentException("table or database is not existed");
   }
 
-  /**
-   * read current row id from TiKV according to database id and table id.
-   */
+  /** read current row id from TiKV according to database id and table id. */
   public static long getAllocateId(long dbId, long tableId, Snapshot snapshot) {
     if (isDBExisted(dbId, snapshot) && isTableExisted(dbId, tableId, snapshot)) {
       ByteString dbKey = MetaCodec.encodeDatabaseID(dbId);

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
@@ -39,8 +39,8 @@ public class RowIDAllocatorTest {
     int count = threads * 10;
     int step = 10000;
     ExecutorService executorService = null;
-    try (ClientSession session = ClientSession.create(
-        new ClientConfig(ConfigUtils.defaultProperties()))) {
+    try (ClientSession session =
+        ClientSession.create(new ClientConfig(ConfigUtils.defaultProperties()))) {
       executorService = Executors.newFixedThreadPool(threads);
       String databaseName = "test";
       String tableName = "test_row_id_allocator";
@@ -51,8 +51,7 @@ public class RowIDAllocatorTest {
 
       for (int i = 1; i <= count; i++) {
         FutureTask<RowIDAllocator> task =
-            new FutureTask<>(
-                () -> session.createRowIdAllocator(databaseName, tableName, step));
+            new FutureTask<>(() -> session.createRowIdAllocator(databaseName, tableName, step));
         tasks.add(task);
         executorService.submit(task);
       }
@@ -67,6 +66,5 @@ public class RowIDAllocatorTest {
         executorService.shutdownNow();
       }
     }
-
   }
 }

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.tidb.bigdata.tidb.allocator;
+
+import io.tidb.bigdata.test.IntegrationTest;
+import io.tidb.bigdata.tidb.ClientConfig;
+import io.tidb.bigdata.tidb.ClientSession;
+import io.tidb.bigdata.tidb.ConfigUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(IntegrationTest.class)
+public class RowIDAllocatorTest {
+
+  @Test
+  public void testCreateRowIDAllocator() throws Exception {
+    int threads = 50;
+    int count = threads * 10;
+    int step = 10000;
+    ExecutorService executorService = null;
+    try (ClientSession session = ClientSession.create(
+        new ClientConfig(ConfigUtils.defaultProperties()))) {
+      executorService = Executors.newFixedThreadPool(threads);
+      String databaseName = "test";
+      String tableName = "test_row_id_allocator";
+      session.sqlUpdate(
+          String.format("DROP TABLE IF EXISTS `%s`.`%s`", databaseName, tableName),
+          String.format("CREATE TABLE `%s`.`%s`(id bigint)", databaseName, tableName));
+      List<FutureTask<RowIDAllocator>> tasks = new ArrayList<>();
+
+      for (int i = 1; i <= count; i++) {
+        FutureTask<RowIDAllocator> task =
+            new FutureTask<>(
+                () -> session.createRowIdAllocator(databaseName, tableName, step));
+        tasks.add(task);
+        executorService.submit(task);
+      }
+      long sum = 0;
+      for (FutureTask<RowIDAllocator> task : tasks) {
+        RowIDAllocator rowIDAllocator = task.get(10, TimeUnit.SECONDS);
+        sum += rowIDAllocator.getEnd() - rowIDAllocator.getStart();
+      }
+      Assert.assertEquals(step * count, sum);
+    } finally {
+      if (executorService != null) {
+        executorService.shutdownNow();
+      }
+    }
+
+  }
+}

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
@@ -58,7 +58,7 @@ public class RowIDAllocatorTest {
       }
       long sum = 0;
       for (FutureTask<RowIDAllocator> task : tasks) {
-        RowIDAllocator rowIDAllocator = task.get(10, TimeUnit.SECONDS);
+        RowIDAllocator rowIDAllocator = task.get(40, TimeUnit.SECONDS);
         sum += rowIDAllocator.getEnd() - rowIDAllocator.getStart();
       }
       Assert.assertEquals(step * count, sum);


### PR DESCRIPTION
## What is the purpose of the change
Fixed conflicts for creating RowIDAllocator.

## Brief change log
1. Set the default lock ttl to 1000ms and  remove random sleep time for flink 1.14 when creating RowIDAllocator.



## Verifying this change

Add some test for creating RowIDAllocator concurrently(50 threads).

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API: no
- The runtime per-record code paths (performance sensitive): no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
