### PR TITLE
Fix unstable test - testCreateRowIDAllocator()

### DIFF
--- a/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/RowIDAllocator.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/allocator/RowIDAllocator.java
@@ -100,7 +100,6 @@ public final class RowIDAllocator implements Serializable {
       } catch (AllocateRowIDOverflowException | IllegalArgumentException e) {
         throw e;
       } catch (Exception e) {
-        LOG.warn("error during allocating row id", e);
         backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoServerBusy, e);
       }
     }

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
@@ -57,7 +57,7 @@ public class RowIDAllocatorTest {
       }
       long sum = 0;
       for (FutureTask<RowIDAllocator> task : tasks) {
-        RowIDAllocator rowIDAllocator = task.get(40, TimeUnit.SECONDS);
+        RowIDAllocator rowIDAllocator = task.get(60, TimeUnit.SECONDS);
         sum += rowIDAllocator.getEnd() - rowIDAllocator.getStart();
       }
       Assert.assertEquals(step * count, sum);

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
@@ -57,7 +57,7 @@ public class RowIDAllocatorTest {
       }
       long sum = 0;
       for (FutureTask<RowIDAllocator> task : tasks) {
-        RowIDAllocator rowIDAllocator = task.get(60, TimeUnit.SECONDS);
+        RowIDAllocator rowIDAllocator = task.get(120, TimeUnit.SECONDS);
         sum += rowIDAllocator.getEnd() - rowIDAllocator.getStart();
       }
       Assert.assertEquals(step * count, sum);


### PR DESCRIPTION
## What is the purpose of the change

testCreateRowIDAllocator() is unstable 

## Brief change log

- delete the warning log, only log when the allocator failed. If allocator is retrying, the log won't be print. [The concrete log already prints the error log](https://github.com/tikv/client-java/blob/master/src/main/java/org/tikv/common/util/ConcreteBackOffer.java#L247-L261)
- extend the test time

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The runtime per-record code paths (performance sensitive): (no)

## Documentation

- Does this pull request introduce a new feature? (no)
