### PR TITLE
Change Kafaka Ci link to repaire stream-test

### DIFF
--- a/.github/workflows/flink-stream-test.yml
+++ b/.github/workflows/flink-stream-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: deploy kafka
         run: |
-          wget https://dlcdn.apache.org/kafka/3.2.0/kafka_2.12-3.2.0.tgz
+          wget https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz
           tar -zxvf kafka_2.12-3.2.0.tgz
           mv kafka_2.12-3.2.0 kafka/
           kafka/bin/zookeeper-server-start.sh kafka/config/zookeeper.properties &


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

## What is the purpose of the change

Change Kafaka Ci link to repaire stream-test.
Change Kafaka link from https://dlcdn.apache.org/kafka/3.2.0/kafka_2.12-3.2.0.tgz to https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz
