### PR TITLE
Optimize tidb-core module API

### DIFF
--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/SnapshotSource.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/SnapshotSource.java
@@ -32,6 +32,7 @@ import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +81,8 @@ public class SnapshotSource
     try (ClientSession session = ClientSession.create(new ClientConfig(properties))) {
       TiTableInfo tiTableInfo = session.getTableMust(databaseName, tableName);
       this.columns =
-          ClientSession.getTableColumns(tiTableInfo, schema.getPhysicalFieldNamesWithoutMeta());
+          ClientSession.getTableColumns(
+              tiTableInfo, Arrays.asList(schema.getPhysicalFieldNamesWithoutMeta()));
       this.timestamp =
           getOptionalVersion()
               .orElseGet(() -> getOptionalTimestamp().orElseGet(session::getSnapshotVersion));

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/SnapshotSource.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/SnapshotSource.java
@@ -26,16 +26,15 @@ import io.tidb.bigdata.flink.connector.source.split.TiDBSourceSplit;
 import io.tidb.bigdata.flink.connector.source.split.TiDBSourceSplitSerializer;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.expression.Expression;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -79,24 +78,16 @@ public class SnapshotSource
     this.expression = expression;
     this.limit = limit;
     try (ClientSession session = ClientSession.create(new ClientConfig(properties))) {
+      TiTableInfo tiTableInfo = session.getTableMust(databaseName, tableName);
       this.columns =
-          session
-              .getTableColumns(databaseName, tableName, schema.getPhysicalFieldNamesWithoutMeta())
-              .orElseThrow(
-                  () ->
-                      new NullPointerException(
-                          "Could not get columns for TiDB table:"
-                              + databaseName
-                              + "."
-                              + tableName));
+          ClientSession.getTableColumns(tiTableInfo, schema.getPhysicalFieldNamesWithoutMeta());
       this.timestamp =
           getOptionalVersion()
               .orElseGet(() -> getOptionalTimestamp().orElseGet(session::getSnapshotVersion));
       TableHandleInternal tableHandleInternal =
-          new TableHandleInternal(UUID.randomUUID().toString(), this.databaseName, this.tableName);
-      SplitManagerInternal splitManagerInternal = new SplitManagerInternal(session);
+          new TableHandleInternal(this.databaseName, tiTableInfo);
       this.splits =
-          splitManagerInternal.getSplits(tableHandleInternal, timestamp).stream()
+          session.getSplits(tableHandleInternal, timestamp).stream()
               .map(TiDBSourceSplit::new)
               .collect(Collectors.toList());
       this.semantic =

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
@@ -58,7 +58,9 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
 
   private ClientSession session;
 
-  /** The availability future. This reader is available as soon as a split is assigned. */
+  /**
+   * The availability future. This reader is available as soon as a split is assigned.
+   */
   private CompletableFuture<Void> availability;
 
   private TiDBSourceSplit currentSplit;
@@ -112,16 +114,14 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
     currentSplit = remainingSplits.poll();
     if (currentSplit != null) {
       SplitInternal split = currentSplit.getSplit();
-      cursor =
-          new RecordSetInternal(
-                  session,
-                  ImmutableList.of(split),
-                  columns,
-                  Optional.ofNullable(expression),
-                  Optional.ofNullable(split.getTimestamp()),
-                  Optional.ofNullable(limit),
-                  semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
-              .cursor();
+      cursor = RecordSetInternal
+          .builder(session, ImmutableList.of(split), columns)
+          .withExpression(expression)
+          .withTimestamp(split.getTimestamp())
+          .withLimit(limit)
+          .withQueryHandle(semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
+          .build()
+          .cursor();
       return InputStatus.MORE_AVAILABLE;
     } else if (noMoreSplits) {
       return InputStatus.END_OF_INPUT;

--- a/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
+++ b/flink/flink-1.13/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
@@ -36,7 +36,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import org.apache.flink.api.connector.source.ReaderOutput;
@@ -58,9 +57,7 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
 
   private ClientSession session;
 
-  /**
-   * The availability future. This reader is available as soon as a split is assigned.
-   */
+  /** The availability future. This reader is available as soon as a split is assigned. */
   private CompletableFuture<Void> availability;
 
   private TiDBSourceSplit currentSplit;
@@ -114,14 +111,14 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
     currentSplit = remainingSplits.poll();
     if (currentSplit != null) {
       SplitInternal split = currentSplit.getSplit();
-      cursor = RecordSetInternal
-          .builder(session, ImmutableList.of(split), columns)
-          .withExpression(expression)
-          .withTimestamp(split.getTimestamp())
-          .withLimit(limit)
-          .withQueryHandle(semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
-          .build()
-          .cursor();
+      cursor =
+          RecordSetInternal.builder(session, ImmutableList.of(split), columns)
+              .withExpression(expression)
+              .withTimestamp(split.getTimestamp())
+              .withLimit(limit)
+              .withQueryHandle(semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
+              .build()
+              .cursor();
       return InputStatus.MORE_AVAILABLE;
     } else if (noMoreSplits) {
       return InputStatus.END_OF_INPUT;

--- a/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -27,7 +27,6 @@ import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.RecordCursorInternal;
 import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.expression.Expression;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
@@ -129,8 +128,7 @@ public class FilterPushDownValidator extends ExternalResource {
   private List<Row> scanRows(String database, String table, Optional<Expression> expression) {
     List<Row> rows = new ArrayList<>();
     List<SplitInternal> splits =
-        new SplitManagerInternal(clientSession)
-            .getSplits(new TableHandleInternal("", database, table));
+        clientSession.getSplits(new TableHandleInternal("", database, table));
     List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
     for (SplitInternal split : splits) {
       RecordCursorInternal cursor =

--- a/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -127,9 +127,10 @@ public class FilterPushDownValidator extends ExternalResource {
 
   private List<Row> scanRows(String database, String table, Optional<Expression> expression) {
     List<Row> rows = new ArrayList<>();
+    TiTableInfo tiTableInfo = clientSession.getTableMust(database, table);
     List<SplitInternal> splits =
-        clientSession.getSplits(new TableHandleInternal("", database, table));
-    List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
+        clientSession.getSplits(new TableHandleInternal(database, tiTableInfo));
+    List<ColumnHandleInternal> columns = ClientSession.getTableColumns(tiTableInfo);
     for (SplitInternal split : splits) {
       RecordCursorInternal cursor =
           RecordSetInternal.builder(clientSession, ImmutableList.of(split), columns)

--- a/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -133,9 +133,14 @@ public class FilterPushDownValidator extends ExternalResource {
             .getSplits(new TableHandleInternal("", database, table));
     List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
     for (SplitInternal split : splits) {
-      RecordSetInternal recordSetInternal =
-          new RecordSetInternal(clientSession, split, columns, expression, Optional.empty());
-      RecordCursorInternal cursor = recordSetInternal.cursor();
+      RecordCursorInternal cursor = RecordSetInternal
+          .builder(clientSession, ImmutableList.of(split), columns)
+          .withExpression(expression.orElse(null))
+          .withTimestamp(null)
+          .withLimit(null)
+          .withQueryHandle(false)
+          .build()
+          .cursor();
       while (cursor.advanceNextPosition()) {
         rows.add(cursor.getRow());
       }
@@ -151,7 +156,9 @@ public class FilterPushDownValidator extends ExternalResource {
     return objects;
   }
 
-  /** Test for expressions and rows. */
+  /**
+   * Test for expressions and rows.
+   */
   public void doTestFilter(
       List<Row> expectedRows, Expression expectedExpression, String whereCondition) {
     List<ResolvedExpression> filters = FilterPushDownTestUtils.getFilters(whereCondition);

--- a/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.13/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -133,14 +133,14 @@ public class FilterPushDownValidator extends ExternalResource {
             .getSplits(new TableHandleInternal("", database, table));
     List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
     for (SplitInternal split : splits) {
-      RecordCursorInternal cursor = RecordSetInternal
-          .builder(clientSession, ImmutableList.of(split), columns)
-          .withExpression(expression.orElse(null))
-          .withTimestamp(null)
-          .withLimit(null)
-          .withQueryHandle(false)
-          .build()
-          .cursor();
+      RecordCursorInternal cursor =
+          RecordSetInternal.builder(clientSession, ImmutableList.of(split), columns)
+              .withExpression(expression.orElse(null))
+              .withTimestamp(null)
+              .withLimit(null)
+              .withQueryHandle(false)
+              .build()
+              .cursor();
       while (cursor.advanceNextPosition()) {
         rows.add(cursor.getRow());
       }
@@ -156,9 +156,7 @@ public class FilterPushDownValidator extends ExternalResource {
     return objects;
   }
 
-  /**
-   * Test for expressions and rows.
-   */
+  /** Test for expressions and rows. */
   public void doTestFilter(
       List<Row> expectedRows, Expression expectedExpression, String whereCondition) {
     List<ResolvedExpression> filters = FilterPushDownTestUtils.getFilters(whereCondition);

--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/TiDBCatalog.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/TiDBCatalog.java
@@ -466,9 +466,11 @@ public class TiDBCatalog extends AbstractCatalog {
     return getClientSession().queryIndexCount(databaseName, tableName, indexName);
   }
 
+  // Only use it for testing
   public RowIDAllocator createRowIDAllocator(
       String databaseName, String tableName, long step, RowIDAllocatorType allocatorType) {
-    return getClientSession().createRowIdAllocator(databaseName, tableName, step, allocatorType);
+    TiTableInfo tiTableInfo = getClientSession().getTableMust(databaseName, tableName);
+    return getClientSession().createRowIdAllocator(databaseName, tiTableInfo, step, allocatorType);
   }
 
   private ClientSession getClientSession() {

--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/source/SnapshotSource.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/source/SnapshotSource.java
@@ -26,17 +26,16 @@ import io.tidb.bigdata.flink.connector.source.split.TiDBSourceSplit;
 import io.tidb.bigdata.flink.connector.source.split.TiDBSourceSplitSerializer;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.expression.Expression;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -53,7 +52,7 @@ import org.tikv.common.meta.TiTimestamp;
 
 public class SnapshotSource
     implements Source<RowData, TiDBSourceSplit, TiDBSourceSplitEnumState>,
-    ResultTypeQueryable<RowData> {
+        ResultTypeQueryable<RowData> {
 
   private final String databaseName;
   private final String tableName;
@@ -82,8 +81,8 @@ public class SnapshotSource
     try (ClientSession session = ClientSession.create(new ClientConfig(properties))) {
       TiTableInfo tiTableInfo = session.getTableMust(databaseName, tableName);
       this.columns =
-          ClientSession
-              .getTableColumns(tiTableInfo, schema.getPhysicalFieldNamesWithoutMeta());
+          ClientSession.getTableColumns(
+              tiTableInfo, Arrays.asList(schema.getPhysicalFieldNamesWithoutMeta()));
       this.timestamp =
           getOptionalVersion()
               .orElseGet(() -> getOptionalTimestamp().orElseGet(session::getSnapshotVersion));

--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
@@ -58,7 +58,9 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
 
   private ClientSession session;
 
-  /** The availability future. This reader is available as soon as a split is assigned. */
+  /**
+   * The availability future. This reader is available as soon as a split is assigned.
+   */
   private CompletableFuture<Void> availability;
 
   private TiDBSourceSplit currentSplit;
@@ -112,16 +114,14 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
     currentSplit = remainingSplits.poll();
     if (currentSplit != null) {
       SplitInternal split = currentSplit.getSplit();
-      cursor =
-          new RecordSetInternal(
-                  session,
-                  ImmutableList.of(split),
-                  columns,
-                  Optional.ofNullable(expression),
-                  Optional.ofNullable(split.getTimestamp()),
-                  Optional.ofNullable(limit),
-                  semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
-              .cursor();
+      cursor = RecordSetInternal
+          .builder(session, ImmutableList.of(split), columns)
+          .withExpression(expression)
+          .withTimestamp(split.getTimestamp())
+          .withLimit(limit)
+          .withQueryHandle(semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
+          .build()
+          .cursor();
       return InputStatus.MORE_AVAILABLE;
     } else if (noMoreSplits) {
       return InputStatus.END_OF_INPUT;

--- a/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
+++ b/flink/flink-1.14/src/main/java/io/tidb/bigdata/flink/connector/source/reader/TiDBSourceReader.java
@@ -36,7 +36,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import org.apache.flink.api.connector.source.ReaderOutput;
@@ -58,9 +57,7 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
 
   private ClientSession session;
 
-  /**
-   * The availability future. This reader is available as soon as a split is assigned.
-   */
+  /** The availability future. This reader is available as soon as a split is assigned. */
   private CompletableFuture<Void> availability;
 
   private TiDBSourceSplit currentSplit;
@@ -114,14 +111,14 @@ public class TiDBSourceReader implements SourceReader<RowData, TiDBSourceSplit> 
     currentSplit = remainingSplits.poll();
     if (currentSplit != null) {
       SplitInternal split = currentSplit.getSplit();
-      cursor = RecordSetInternal
-          .builder(session, ImmutableList.of(split), columns)
-          .withExpression(expression)
-          .withTimestamp(split.getTimestamp())
-          .withLimit(limit)
-          .withQueryHandle(semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
-          .build()
-          .cursor();
+      cursor =
+          RecordSetInternal.builder(session, ImmutableList.of(split), columns)
+              .withExpression(expression)
+              .withTimestamp(split.getTimestamp())
+              .withLimit(limit)
+              .withQueryHandle(semantic == SnapshotSourceSemantic.EXACTLY_ONCE)
+              .build()
+              .cursor();
       return InputStatus.MORE_AVAILABLE;
     } else if (noMoreSplits) {
       return InputStatus.END_OF_INPUT;

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -27,7 +27,6 @@ import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.RecordCursorInternal;
 import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.expression.Expression;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
@@ -129,8 +128,7 @@ public class FilterPushDownValidator extends ExternalResource {
   private List<Row> scanRows(String database, String table, Optional<Expression> expression) {
     List<Row> rows = new ArrayList<>();
     List<SplitInternal> splits =
-        new SplitManagerInternal(clientSession)
-            .getSplits(new TableHandleInternal("", database, table));
+        clientSession.getSplits(new TableHandleInternal("", database, table));
     List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
     for (SplitInternal split : splits) {
       RecordCursorInternal cursor =

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -127,9 +127,10 @@ public class FilterPushDownValidator extends ExternalResource {
 
   private List<Row> scanRows(String database, String table, Optional<Expression> expression) {
     List<Row> rows = new ArrayList<>();
+    TiTableInfo tiTableInfo = clientSession.getTableMust(database, table);
     List<SplitInternal> splits =
-        clientSession.getSplits(new TableHandleInternal("", database, table));
-    List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
+        clientSession.getSplits(new TableHandleInternal(database, tiTableInfo));
+    List<ColumnHandleInternal> columns = ClientSession.getTableColumns(tiTableInfo);
     for (SplitInternal split : splits) {
       RecordCursorInternal cursor =
           RecordSetInternal.builder(clientSession, ImmutableList.of(split), columns)

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -133,14 +133,14 @@ public class FilterPushDownValidator extends ExternalResource {
             .getSplits(new TableHandleInternal("", database, table));
     List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
     for (SplitInternal split : splits) {
-      RecordCursorInternal cursor = RecordSetInternal
-          .builder(clientSession, ImmutableList.of(split), columns)
-          .withExpression(expression.orElse(null))
-          .withTimestamp(null)
-          .withLimit(null)
-          .withQueryHandle(false)
-          .build()
-          .cursor();
+      RecordCursorInternal cursor =
+          RecordSetInternal.builder(clientSession, ImmutableList.of(split), columns)
+              .withExpression(expression.orElse(null))
+              .withTimestamp(null)
+              .withLimit(null)
+              .withQueryHandle(false)
+              .build()
+              .cursor();
       while (cursor.advanceNextPosition()) {
         rows.add(cursor.getRow());
       }

--- a/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
+++ b/flink/flink-1.14/src/test/java/io/tidb/bigdata/flink/tidb/pushdown/FilterPushDownValidator.java
@@ -133,9 +133,14 @@ public class FilterPushDownValidator extends ExternalResource {
             .getSplits(new TableHandleInternal("", database, table));
     List<ColumnHandleInternal> columns = clientSession.getTableColumnsMust(database, table);
     for (SplitInternal split : splits) {
-      RecordSetInternal recordSetInternal =
-          new RecordSetInternal(clientSession, split, columns, expression, Optional.empty());
-      RecordCursorInternal cursor = recordSetInternal.cursor();
+      RecordCursorInternal cursor = RecordSetInternal
+          .builder(clientSession, ImmutableList.of(split), columns)
+          .withExpression(expression.orElse(null))
+          .withTimestamp(null)
+          .withLimit(null)
+          .withQueryHandle(false)
+          .build()
+          .cursor();
       while (cursor.advanceNextPosition()) {
         rows.add(cursor.getRow());
       }

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseRowDataInputFormat.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseRowDataInputFormat.java
@@ -217,17 +217,18 @@ public abstract class TiDBBaseRowDataInputFormat extends RichInputFormat<RowData
       return;
     }
     SplitInternal splitInternal = splits.get(split.getSplitNumber());
-    List<ColumnHandleInternal> columns = Arrays.stream(projectedFieldIndexes)
-        .mapToObj(columnHandleInternals::get)
-        .collect(Collectors.toList());
-    cursor = RecordSetInternal
-        .builder(clientSession, ImmutableList.of(splitInternal), columns)
-        .withExpression(expression)
-        .withTimestamp(timestamp)
-        .withLimit(limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit)
-        .withQueryHandle(false)
-        .build()
-        .cursor();
+    List<ColumnHandleInternal> columns =
+        Arrays.stream(projectedFieldIndexes)
+            .mapToObj(columnHandleInternals::get)
+            .collect(Collectors.toList());
+    cursor =
+        RecordSetInternal.builder(clientSession, ImmutableList.of(splitInternal), columns)
+            .withExpression(expression)
+            .withTimestamp(timestamp)
+            .withLimit(limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit)
+            .withQueryHandle(false)
+            .build()
+            .cursor();
   }
 
   @Override
@@ -255,10 +256,10 @@ public abstract class TiDBBaseRowDataInputFormat extends RichInputFormat<RowData
           i,
           toRowDataType(
               getObjectWithDataType(
-                  object,
-                  fieldType,
-                  columnHandleInternals.get(projectedFieldIndex).getType(),
-                  formatters[projectedFieldIndex])
+                      object,
+                      fieldType,
+                      columnHandleInternals.get(projectedFieldIndex).getType(),
+                      formatters[projectedFieldIndex])
                   .orElse(null)));
     }
     recordCount++;

--- a/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseRowDataInputFormat.java
+++ b/flink/flink-base/src/main/java/io/tidb/bigdata/flink/tidb/TiDBBaseRowDataInputFormat.java
@@ -28,7 +28,6 @@ import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.RecordCursorInternal;
 import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.expression.Expression;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
@@ -122,8 +121,7 @@ public abstract class TiDBBaseRowDataInputFormat extends RichInputFormat<RowData
       splitSession.getTableMust(databaseName, tableName);
       TableHandleInternal tableHandleInternal =
           new TableHandleInternal(UUID.randomUUID().toString(), this.databaseName, this.tableName);
-      SplitManagerInternal splitManagerInternal = new SplitManagerInternal(splitSession);
-      this.splits = splitManagerInternal.getSplits(tableHandleInternal);
+      this.splits = splitSession.getSplits(tableHandleInternal);
       columns =
           splitSession
               .getTableColumns(tableHandleInternal)

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -17,7 +17,6 @@
 package io.tidb.bigdata.hive;
 
 import static io.tidb.bigdata.hive.TiDBConstant.DATABASE_NAME;
-import static io.tidb.bigdata.hive.TiDBConstant.EMPTY_STRING;
 import static io.tidb.bigdata.hive.TiDBConstant.REGIONS_PER_SPLIT;
 import static io.tidb.bigdata.hive.TiDBConstant.TABLE_NAME;
 
@@ -55,7 +54,8 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
       Integer regionNumPerSplit = jobConf.getInt(REGIONS_PER_SPLIT, 1);
 
       TableHandleInternal tableHandle =
-          new TableHandleInternal(EMPTY_STRING, databaseName, tableName);
+          new TableHandleInternal(
+              databaseName, tableName, clientSession.getTableMust(databaseName, tableName));
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
       List<SplitInternal> splits = new SplitManagerInternal(clientSession).getSplits(tableHandle);

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import java.io.IOException;
 import java.util.HashMap;
@@ -58,7 +57,7 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
               databaseName, tableName, clientSession.getTableMust(databaseName, tableName));
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
-      List<SplitInternal> splits = new SplitManagerInternal(clientSession).getSplits(tableHandle);
+      List<SplitInternal> splits = clientSession.getSplits(tableHandle);
       List<List<SplitInternal>> splitPartition = Lists.partition(splits, regionNumPerSplit);
 
       return splitPartition.stream()

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -25,6 +25,7 @@ import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -52,9 +53,8 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
           Objects.requireNonNull(jobConf.get(DATABASE_NAME), DATABASE_NAME + " can not be null");
       Integer regionNumPerSplit = jobConf.getInt(REGIONS_PER_SPLIT, 1);
 
-      TableHandleInternal tableHandle =
-          new TableHandleInternal(
-              databaseName, tableName, clientSession.getTableMust(databaseName, tableName));
+      TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
+      TableHandleInternal tableHandle = new TableHandleInternal(databaseName, tiTableInfo);
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
       List<SplitInternal> splits = clientSession.getSplits(tableHandle);

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
@@ -33,8 +33,7 @@ public class TiDBInputSplit extends FileSplit {
   private Path path;
   private List<SplitInternal> splitInternals;
 
-  public TiDBInputSplit() {
-  }
+  public TiDBInputSplit() {}
 
   public TiDBInputSplit(Path path, List<SplitInternal> splitInternals) {
     this.path = path;

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
@@ -33,7 +33,8 @@ public class TiDBInputSplit extends FileSplit {
   private Path path;
   private List<SplitInternal> splitInternals;
 
-  public TiDBInputSplit() {}
+  public TiDBInputSplit() {
+  }
 
   public TiDBInputSplit(Path path, List<SplitInternal> splitInternals) {
     this.path = path;
@@ -66,7 +67,7 @@ public class TiDBInputSplit extends FileSplit {
     for (int i = 0; i < splitInternals.size(); i++) {
       SplitInternal splitInternal = splitInternals.get(i);
       dataOutput.writeUTF(splitInternal.getTable().getSchemaName());
-      dataOutput.writeUTF(splitInternal.getTable().getTiTableInfoBase64StringMust());
+      dataOutput.writeUTF(splitInternal.getTable().getTiTableInfoBase64String());
       dataOutput.writeUTF(splitInternal.getStartKey());
       dataOutput.writeUTF(splitInternal.getEndKey());
       dataOutput.writeLong(splitInternal.getTimestamp().getPhysical());

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -69,20 +69,18 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
 
   private void initCursor() {
     SplitInternal splitInternal = splitInternals.get(0);
-    columns =
-        clientSession.getTableColumnsMust(
-            splitInternal.getTable().getSchemaName(), splitInternal.getTable().getTableName());
+    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfoMust());
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));
-    RecordSetInternal recordSetInternal =
-        new RecordSetInternal(
-            clientSession,
-            splitInternals,
-            columns,
-            Optional.empty(),
-            Optional.ofNullable(timestamp));
-    cursor = recordSetInternal.cursor();
+    cursor =
+        RecordSetInternal.builder(clientSession, splitInternals, columns)
+            .withExpression(null)
+            .withTimestamp(timestamp)
+            .withLimit(null)
+            .withQueryHandle(false)
+            .build()
+            .cursor();
   }
 
   @Override

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -69,7 +69,7 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
 
   private void initCursor() {
     SplitInternal splitInternal = splitInternals.get(0);
-    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfoMust());
+    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfo());
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));

--- a/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBSerde.java
+++ b/hive/hive-2.2.0/src/main/java/io/tidb/bigdata/hive/TiDBSerde.java
@@ -22,6 +22,7 @@ import static io.tidb.bigdata.hive.TiDBConstant.TABLE_NAME;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -113,7 +114,8 @@ public class TiDBSerde extends AbstractSerDe {
     if (columns == null) {
       Map<String, String> map = new HashMap<>((Map) properties);
       try (ClientSession clientSession = ClientSession.create(new ClientConfig(map))) {
-        columns = clientSession.getTableColumnsMust(databaseName, tableName);
+        TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
+        columns = ClientSession.getTableColumns(tiTableInfo);
       } catch (Exception e) {
         throw new IllegalStateException(e);
       }

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import java.io.IOException;
 import java.util.HashMap;
@@ -58,7 +57,7 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
           new TableHandleInternal(EMPTY_STRING, databaseName, tableName);
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
-      List<SplitInternal> splits = new SplitManagerInternal(clientSession).getSplits(tableHandle);
+      List<SplitInternal> splits = clientSession.getSplits(tableHandle);
       List<List<SplitInternal>> splitPartition = Lists.partition(splits, regionNumPerSplit);
 
       return splitPartition.stream()

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -17,7 +17,6 @@
 package io.tidb.bigdata.hive;
 
 import static io.tidb.bigdata.hive.TiDBConstant.DATABASE_NAME;
-import static io.tidb.bigdata.hive.TiDBConstant.EMPTY_STRING;
 import static io.tidb.bigdata.hive.TiDBConstant.REGIONS_PER_SPLIT;
 import static io.tidb.bigdata.hive.TiDBConstant.TABLE_NAME;
 

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -26,6 +26,7 @@ import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -53,8 +54,8 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
           Objects.requireNonNull(jobConf.get(DATABASE_NAME), DATABASE_NAME + " can not be null");
       Integer regionNumPerSplit = jobConf.getInt(REGIONS_PER_SPLIT, 1);
 
-      TableHandleInternal tableHandle =
-          new TableHandleInternal(EMPTY_STRING, databaseName, tableName);
+      TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
+      TableHandleInternal tableHandle = new TableHandleInternal(databaseName, tiTableInfo);
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
       List<SplitInternal> splits = clientSession.getSplits(tableHandle);

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
@@ -18,12 +18,12 @@ package io.tidb.bigdata.hive;
 
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
 import org.tikv.common.meta.TiTimestamp;
@@ -33,7 +33,8 @@ public class TiDBInputSplit extends FileSplit {
   private Path path;
   private List<SplitInternal> splitInternals;
 
-  public TiDBInputSplit() {}
+  public TiDBInputSplit() {
+  }
 
   public TiDBInputSplit(Path path, List<SplitInternal> splitInternals) {
     this.path = path;
@@ -64,12 +65,13 @@ public class TiDBInputSplit extends FileSplit {
     dataOutput.writeUTF(path.toString());
     dataOutput.writeInt(splitInternals.size());
     for (int i = 0; i < splitInternals.size(); i++) {
-      dataOutput.writeUTF(splitInternals.get(i).getTable().getSchemaName());
-      dataOutput.writeUTF(splitInternals.get(i).getTable().getTableName());
-      dataOutput.writeUTF(splitInternals.get(i).getStartKey());
-      dataOutput.writeUTF(splitInternals.get(i).getEndKey());
-      dataOutput.writeLong(splitInternals.get(i).getTimestamp().getPhysical());
-      dataOutput.writeLong(splitInternals.get(i).getTimestamp().getLogical());
+      SplitInternal splitInternal = splitInternals.get(i);
+      dataOutput.writeUTF(splitInternal.getTable().getSchemaName());
+      dataOutput.writeUTF(splitInternal.getTable().getTiTableInfoBase64String());
+      dataOutput.writeUTF(splitInternal.getStartKey());
+      dataOutput.writeUTF(splitInternal.getEndKey());
+      dataOutput.writeLong(splitInternal.getTimestamp().getPhysical());
+      dataOutput.writeLong(splitInternal.getTimestamp().getLogical());
     }
   }
 
@@ -80,7 +82,7 @@ public class TiDBInputSplit extends FileSplit {
     List<SplitInternal> splitInternalList = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
       String databaseName = dataInput.readUTF();
-      String tableName = dataInput.readUTF();
+      TiTableInfo tiTableInfo = TableHandleInternal.decodeTiTableInfo(dataInput.readUTF());
       String startKey = dataInput.readUTF();
       String endKey = dataInput.readUTF();
       Long physicalTimestamp = dataInput.readLong();
@@ -88,7 +90,7 @@ public class TiDBInputSplit extends FileSplit {
 
       SplitInternal splitInternal =
           new SplitInternal(
-              new TableHandleInternal(UUID.randomUUID().toString(), databaseName, tableName),
+              new TableHandleInternal(databaseName, tiTableInfo),
               startKey,
               endKey,
               new TiTimestamp(physicalTimestamp, logicalTimestamp));

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
@@ -33,8 +33,7 @@ public class TiDBInputSplit extends FileSplit {
   private Path path;
   private List<SplitInternal> splitInternals;
 
-  public TiDBInputSplit() {
-  }
+  public TiDBInputSplit() {}
 
   public TiDBInputSplit(Path path, List<SplitInternal> splitInternals) {
     this.path = path;

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -73,14 +73,14 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));
-    cursor = RecordSetInternal
-        .builder(clientSession, splitInternals, columns)
-        .withExpression(null)
-        .withTimestamp(timestamp)
-        .withLimit(null)
-        .withQueryHandle(false)
-        .build()
-        .cursor();
+    cursor =
+        RecordSetInternal.builder(clientSession, splitInternals, columns)
+            .withExpression(null)
+            .withTimestamp(timestamp)
+            .withLimit(null)
+            .withQueryHandle(false)
+            .build()
+            .cursor();
   }
 
   @Override

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -69,20 +69,18 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
 
   private void initCursor() {
     SplitInternal splitInternal = splitInternals.get(0);
-    columns =
-        clientSession.getTableColumnsMust(
-            splitInternal.getTable().getSchemaName(), splitInternal.getTable().getTableName());
+    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfoMust());
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));
-    RecordSetInternal recordSetInternal =
-        new RecordSetInternal(
-            clientSession,
-            splitInternals,
-            columns,
-            Optional.empty(),
-            Optional.ofNullable(timestamp));
-    cursor = recordSetInternal.cursor();
+    cursor = RecordSetInternal
+        .builder(clientSession, splitInternals, columns)
+        .withExpression(null)
+        .withTimestamp(timestamp)
+        .withLimit(null)
+        .withQueryHandle(false)
+        .build()
+        .cursor();
   }
 
   @Override

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -69,7 +69,7 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
 
   private void initCursor() {
     SplitInternal splitInternal = splitInternals.get(0);
-    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfoMust());
+    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfo());
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));

--- a/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBSerde.java
+++ b/hive/hive-2.3.6/src/main/java/io/tidb/bigdata/hive/TiDBSerde.java
@@ -22,6 +22,7 @@ import static io.tidb.bigdata.hive.TiDBConstant.TABLE_NAME;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,7 @@ public class TiDBSerde extends AbstractSerDe {
 
   private String databaseName;
   private String tableName;
+  private Properties properties;
   private List<ColumnHandleInternal> columns;
 
   @Override
@@ -55,12 +57,7 @@ public class TiDBSerde extends AbstractSerDe {
     this.databaseName =
         Objects.requireNonNull(
             properties.getProperty(DATABASE_NAME), DATABASE_NAME + " can not be null");
-    Map<String, String> map = new HashMap<>((Map) properties);
-    try (ClientSession clientSession = ClientSession.create(new ClientConfig(map))) {
-      columns = clientSession.getTableColumnsMust(databaseName, tableName);
-    } catch (Exception e) {
-      throw new SerDeException(e);
-    }
+    this.properties = properties;
   }
 
   @Override
@@ -72,6 +69,7 @@ public class TiDBSerde extends AbstractSerDe {
   public Writable serialize(Object o, ObjectInspector objectInspector) throws SerDeException {
     Object[] objects = (Object[]) o;
     MapWritable mapWritable = new MapWritable();
+    List<ColumnHandleInternal> columns = getColumns();
     for (int i = 0; i < columns.size(); i++) {
       ColumnHandleInternal column = columns.get(i);
       String name = column.getName();
@@ -89,6 +87,7 @@ public class TiDBSerde extends AbstractSerDe {
   @Override
   public Object deserialize(Writable writable) throws SerDeException {
     MapWritable mapWritable = (MapWritable) writable;
+    List<ColumnHandleInternal> columns = getColumns();
     Object[] objects = new Object[columns.size()];
     for (int i = 0; i < columns.size(); i++) {
       ColumnHandleInternal column = columns.get(i);
@@ -103,10 +102,24 @@ public class TiDBSerde extends AbstractSerDe {
 
   @Override
   public ObjectInspector getObjectInspector() throws SerDeException {
+    List<ColumnHandleInternal> columns = getColumns();
     List<ObjectInspector> list = new ArrayList<>();
     columns.forEach(column -> list.add(TypeUtils.toObjectInspector(column.getType())));
     List<String> columnNames =
         columns.stream().map(ColumnHandleInternal::getName).collect(Collectors.toList());
     return ObjectInspectorFactory.getStandardStructObjectInspector(columnNames, list);
+  }
+
+  private synchronized List<ColumnHandleInternal> getColumns() {
+    if (columns == null) {
+      Map<String, String> map = new HashMap<>((Map) properties);
+      try (ClientSession clientSession = ClientSession.create(new ClientConfig(map))) {
+        TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
+        columns = ClientSession.getTableColumns(tiTableInfo);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return columns;
   }
 }

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import java.io.IOException;
 import java.util.HashMap;
@@ -58,7 +57,7 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
           new TableHandleInternal(EMPTY_STRING, databaseName, tableName);
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
-      List<SplitInternal> splits = new SplitManagerInternal(clientSession).getSplits(tableHandle);
+      List<SplitInternal> splits = clientSession.getSplits(tableHandle);
       List<List<SplitInternal>> splitPartition = Lists.partition(splits, regionNumPerSplit);
 
       return splitPartition.stream()

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -17,7 +17,6 @@
 package io.tidb.bigdata.hive;
 
 import static io.tidb.bigdata.hive.TiDBConstant.DATABASE_NAME;
-import static io.tidb.bigdata.hive.TiDBConstant.EMPTY_STRING;
 import static io.tidb.bigdata.hive.TiDBConstant.REGIONS_PER_SPLIT;
 import static io.tidb.bigdata.hive.TiDBConstant.TABLE_NAME;
 

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBHiveInputFormat.java
@@ -26,6 +26,7 @@ import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -53,8 +54,8 @@ public class TiDBHiveInputFormat implements InputFormat<LongWritable, MapWritabl
           Objects.requireNonNull(jobConf.get(DATABASE_NAME), DATABASE_NAME + " can not be null");
       Integer regionNumPerSplit = jobConf.getInt(REGIONS_PER_SPLIT, 1);
 
-      TableHandleInternal tableHandle =
-          new TableHandleInternal(EMPTY_STRING, databaseName, tableName);
+      TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
+      TableHandleInternal tableHandle = new TableHandleInternal(databaseName, tiTableInfo);
       Path path = FileInputFormat.getInputPaths(jobConf)[0];
 
       List<SplitInternal> splits = clientSession.getSplits(tableHandle);

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
@@ -18,12 +18,12 @@ package io.tidb.bigdata.hive;
 
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
 import org.tikv.common.meta.TiTimestamp;
@@ -33,7 +33,8 @@ public class TiDBInputSplit extends FileSplit {
   private Path path;
   private List<SplitInternal> splitInternals;
 
-  public TiDBInputSplit() {}
+  public TiDBInputSplit() {
+  }
 
   public TiDBInputSplit(Path path, List<SplitInternal> splitInternals) {
     this.path = path;
@@ -64,12 +65,13 @@ public class TiDBInputSplit extends FileSplit {
     dataOutput.writeUTF(path.toString());
     dataOutput.writeInt(splitInternals.size());
     for (int i = 0; i < splitInternals.size(); i++) {
-      dataOutput.writeUTF(splitInternals.get(i).getTable().getSchemaName());
-      dataOutput.writeUTF(splitInternals.get(i).getTable().getTableName());
-      dataOutput.writeUTF(splitInternals.get(i).getStartKey());
-      dataOutput.writeUTF(splitInternals.get(i).getEndKey());
-      dataOutput.writeLong(splitInternals.get(i).getTimestamp().getPhysical());
-      dataOutput.writeLong(splitInternals.get(i).getTimestamp().getLogical());
+      SplitInternal splitInternal = splitInternals.get(i);
+      dataOutput.writeUTF(splitInternal.getTable().getSchemaName());
+      dataOutput.writeUTF(splitInternal.getTable().getTiTableInfoBase64String());
+      dataOutput.writeUTF(splitInternal.getStartKey());
+      dataOutput.writeUTF(splitInternal.getEndKey());
+      dataOutput.writeLong(splitInternal.getTimestamp().getPhysical());
+      dataOutput.writeLong(splitInternal.getTimestamp().getLogical());
     }
   }
 
@@ -80,7 +82,7 @@ public class TiDBInputSplit extends FileSplit {
     List<SplitInternal> splitInternalList = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
       String databaseName = dataInput.readUTF();
-      String tableName = dataInput.readUTF();
+      TiTableInfo tiTableInfo = TableHandleInternal.decodeTiTableInfo(dataInput.readUTF());
       String startKey = dataInput.readUTF();
       String endKey = dataInput.readUTF();
       Long physicalTimestamp = dataInput.readLong();
@@ -88,7 +90,7 @@ public class TiDBInputSplit extends FileSplit {
 
       SplitInternal splitInternal =
           new SplitInternal(
-              new TableHandleInternal(UUID.randomUUID().toString(), databaseName, tableName),
+              new TableHandleInternal(databaseName, tiTableInfo),
               startKey,
               endKey,
               new TiTimestamp(physicalTimestamp, logicalTimestamp));

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBInputSplit.java
@@ -33,8 +33,7 @@ public class TiDBInputSplit extends FileSplit {
   private Path path;
   private List<SplitInternal> splitInternals;
 
-  public TiDBInputSplit() {
-  }
+  public TiDBInputSplit() {}
 
   public TiDBInputSplit(Path path, List<SplitInternal> splitInternals) {
     this.path = path;

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -73,14 +73,14 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));
-    cursor = RecordSetInternal
-        .builder(clientSession, splitInternals, columns)
-        .withExpression(null)
-        .withTimestamp(timestamp)
-        .withLimit(null)
-        .withQueryHandle(false)
-        .build()
-        .cursor();
+    cursor =
+        RecordSetInternal.builder(clientSession, splitInternals, columns)
+            .withExpression(null)
+            .withTimestamp(timestamp)
+            .withLimit(null)
+            .withQueryHandle(false)
+            .build()
+            .cursor();
   }
 
   @Override

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -69,20 +69,18 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
 
   private void initCursor() {
     SplitInternal splitInternal = splitInternals.get(0);
-    columns =
-        clientSession.getTableColumnsMust(
-            splitInternal.getTable().getSchemaName(), splitInternal.getTable().getTableName());
+    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfoMust());
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));
-    RecordSetInternal recordSetInternal =
-        new RecordSetInternal(
-            clientSession,
-            splitInternals,
-            columns,
-            Optional.empty(),
-            Optional.ofNullable(timestamp));
-    cursor = recordSetInternal.cursor();
+    cursor = RecordSetInternal
+        .builder(clientSession, splitInternals, columns)
+        .withExpression(null)
+        .withTimestamp(timestamp)
+        .withLimit(null)
+        .withQueryHandle(false)
+        .build()
+        .cursor();
   }
 
   @Override

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBRecordReader.java
@@ -69,7 +69,7 @@ public class TiDBRecordReader implements RecordReader<LongWritable, MapWritable>
 
   private void initCursor() {
     SplitInternal splitInternal = splitInternals.get(0);
-    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfoMust());
+    columns = ClientSession.getTableColumns(splitInternal.getTable().getTiTableInfo());
     TiTimestamp timestamp =
         getOptionalVersion()
             .orElseGet(() -> getOptionalTimestamp().orElseGet(splitInternal::getTimestamp));

--- a/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBSerde.java
+++ b/hive/hive-3.1.2/src/main/java/io/tidb/bigdata/hive/TiDBSerde.java
@@ -22,6 +22,7 @@ import static io.tidb.bigdata.hive.TiDBConstant.TABLE_NAME;
 import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,7 @@ public class TiDBSerde extends AbstractSerDe {
 
   private String databaseName;
   private String tableName;
+  private Properties properties;
   private List<ColumnHandleInternal> columns;
 
   @Override
@@ -55,12 +57,7 @@ public class TiDBSerde extends AbstractSerDe {
     this.databaseName =
         Objects.requireNonNull(
             properties.getProperty(DATABASE_NAME), DATABASE_NAME + " can not be null");
-    Map<String, String> map = new HashMap<>((Map) properties);
-    try (ClientSession clientSession = ClientSession.create(new ClientConfig(map))) {
-      columns = clientSession.getTableColumnsMust(databaseName, tableName);
-    } catch (Exception e) {
-      throw new SerDeException(e);
-    }
+    this.properties = properties;
   }
 
   @Override
@@ -72,6 +69,7 @@ public class TiDBSerde extends AbstractSerDe {
   public Writable serialize(Object o, ObjectInspector objectInspector) throws SerDeException {
     Object[] objects = (Object[]) o;
     MapWritable mapWritable = new MapWritable();
+    List<ColumnHandleInternal> columns = getColumns();
     for (int i = 0; i < columns.size(); i++) {
       ColumnHandleInternal column = columns.get(i);
       String name = column.getName();
@@ -89,6 +87,7 @@ public class TiDBSerde extends AbstractSerDe {
   @Override
   public Object deserialize(Writable writable) throws SerDeException {
     MapWritable mapWritable = (MapWritable) writable;
+    List<ColumnHandleInternal> columns = getColumns();
     Object[] objects = new Object[columns.size()];
     for (int i = 0; i < columns.size(); i++) {
       ColumnHandleInternal column = columns.get(i);
@@ -103,10 +102,24 @@ public class TiDBSerde extends AbstractSerDe {
 
   @Override
   public ObjectInspector getObjectInspector() throws SerDeException {
+    List<ColumnHandleInternal> columns = getColumns();
     List<ObjectInspector> list = new ArrayList<>();
     columns.forEach(column -> list.add(TypeUtils.toObjectInspector(column.getType())));
     List<String> columnNames =
         columns.stream().map(ColumnHandleInternal::getName).collect(Collectors.toList());
     return ObjectInspectorFactory.getStandardStructObjectInspector(columnNames, list);
+  }
+
+  private synchronized List<ColumnHandleInternal> getColumns() {
+    if (columns == null) {
+      Map<String, String> map = new HashMap<>((Map) properties);
+      try (ClientSession clientSession = ClientSession.create(new ClientConfig(map))) {
+        TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
+        columns = ClientSession.getTableColumns(tiTableInfo);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return columns;
   }
 }

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputFormat.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputFormat.java
@@ -22,7 +22,6 @@ import static io.tidb.bigdata.mapreduce.tidb.TiDBConfiguration.REGIONS_PER_SPLIT
 import com.google.common.collect.Lists;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import java.sql.Connection;
@@ -73,8 +72,7 @@ public class TiDBInputFormat<T extends TiDBWritable> extends InputFormat<LongWri
    */
   @Override
   public List<InputSplit> getSplits(JobContext job) {
-    SplitManagerInternal splitManagerInternal = new SplitManagerInternal(clientSession);
-    List<SplitInternal> splitInternals = splitManagerInternal.getSplits(tableHandleInternal);
+    List<SplitInternal> splitInternals = clientSession.getSplits(tableHandleInternal);
     int regionsPerSplit =
         job.getConfiguration().getInt(REGIONS_PER_SPLIT, REGIONS_PER_SPLIT_DEFAULT);
     return Lists.partition(splitInternals, regionsPerSplit).stream()

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputFormat.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputFormat.java
@@ -31,7 +31,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -64,8 +63,7 @@ public class TiDBInputFormat<T extends TiDBWritable> extends InputFormat<LongWri
 
   private ResultSetMetaData resultSetMetaData;
 
-  public TiDBInputFormat() {
-  }
+  public TiDBInputFormat() {}
 
   /**
    * {@inheritDoc}
@@ -105,8 +103,7 @@ public class TiDBInputFormat<T extends TiDBWritable> extends InputFormat<LongWri
 
     TiTableInfo tiTableInfo = clientSession.getTableMust(databaseName, tableName);
 
-    this.tableHandleInternal =
-        new TableHandleInternal(databaseName, tiTableInfo);
+    this.tableHandleInternal = new TableHandleInternal(databaseName, tiTableInfo);
 
     String[] fieldNames =
         Arrays.stream(dbConf.getInputFieldNames()).map(String::toLowerCase).toArray(String[]::new);
@@ -120,7 +117,8 @@ public class TiDBInputFormat<T extends TiDBWritable> extends InputFormat<LongWri
               .toArray(new String[columnHandleInternals.size()]);
       dbConf.setInputFieldNames(fieldNames);
     } else {
-      this.columnHandleInternals = ClientSession.getTableColumns(tiTableInfo, fieldNames);
+      this.columnHandleInternals =
+          ClientSession.getTableColumns(tiTableInfo, Arrays.asList(fieldNames));
     }
 
     conf.setStrings(
@@ -163,13 +161,13 @@ public class TiDBInputFormat<T extends TiDBWritable> extends InputFormat<LongWri
   /**
    * Initializes the map-part of the job with the appropriate input settings.
    *
-   * @param job        The map-reduce job
+   * @param job The map-reduce job
    * @param inputClass the class object implementing TiDBWritable, which is the Java object holding
-   *                   tuple fields.
-   * @param tableName  The table to read data from
+   *     tuple fields.
+   * @param tableName The table to read data from
    * @param fieldNames The field names in the table
-   * @param limit      the limit of per mapper read record
-   * @param snapshot   snapshot time
+   * @param limit the limit of per mapper read record
+   * @param snapshot snapshot time
    * @see #setInput(Job, Class, String, String[], java.lang.Integer, String)
    */
   public static void setInput(
@@ -183,7 +181,7 @@ public class TiDBInputFormat<T extends TiDBWritable> extends InputFormat<LongWri
     dbConf.setInputClass(inputClass);
     dbConf.setInputTableName(tableName);
     if (null == fieldNames || 0 == fieldNames.length) {
-      dbConf.setInputFieldNames(new String[]{"*"});
+      dbConf.setInputFieldNames(new String[] {"*"});
     } else {
       dbConf.setInputFieldNames(fieldNames);
     }

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputSplit.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputSplit.java
@@ -18,6 +18,7 @@ package io.tidb.bigdata.mapreduce.tidb;
 
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -34,7 +35,8 @@ public class TiDBInputSplit extends InputSplit implements Writable {
 
   public static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-  public TiDBInputSplit() {}
+  public TiDBInputSplit() {
+  }
 
   public TiDBInputSplit(List<SplitInternal> splitInternals) {
     this.splitInternals = splitInternals;
@@ -59,7 +61,7 @@ public class TiDBInputSplit extends InputSplit implements Writable {
     dataOutput.writeInt(splitInternals.size());
     for (SplitInternal splitInternal : splitInternals) {
       dataOutput.writeUTF(splitInternal.getTable().getSchemaName());
-      dataOutput.writeUTF(splitInternal.getTable().getTableName());
+      dataOutput.writeUTF(splitInternal.getTable().getTiTableInfoBase64String());
       dataOutput.writeUTF(splitInternal.getStartKey());
       dataOutput.writeUTF(splitInternal.getEndKey());
       dataOutput.writeLong(splitInternal.getTimestamp().getPhysical());
@@ -73,7 +75,7 @@ public class TiDBInputSplit extends InputSplit implements Writable {
     List<SplitInternal> splitInternalList = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
       String databaseName = dataInput.readUTF();
-      String tableName = dataInput.readUTF();
+      TiTableInfo tiTableInfo = TableHandleInternal.decodeTiTableInfo(dataInput.readUTF());
       String startKey = dataInput.readUTF();
       String endKey = dataInput.readUTF();
       long physicalTimestamp = dataInput.readLong();
@@ -81,7 +83,7 @@ public class TiDBInputSplit extends InputSplit implements Writable {
 
       SplitInternal splitInternal =
           new SplitInternal(
-              new TableHandleInternal(UUID.randomUUID().toString(), databaseName, tableName),
+              new TableHandleInternal(databaseName, tiTableInfo),
               startKey,
               endKey,
               new TiTimestamp(physicalTimestamp, logicalTimestamp));

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputSplit.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBInputSplit.java
@@ -24,7 +24,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.tikv.common.meta.TiTimestamp;
@@ -35,8 +34,7 @@ public class TiDBInputSplit extends InputSplit implements Writable {
 
   public static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-  public TiDBInputSplit() {
-  }
+  public TiDBInputSplit() {}
 
   public TiDBInputSplit(List<SplitInternal> splitInternals) {
     this.splitInternals = splitInternals;

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBRecordReader.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBRecordReader.java
@@ -111,17 +111,17 @@ public class TiDBRecordReader<T extends TiDBWritable> extends RecordReader<LongW
       key = new LongWritable();
     }
     if (cursor == null) {
-      RecordSetInternal recordSetInternal =
-          new RecordSetInternal(
-              clientSession,
-              splitInternals,
-              Arrays.stream(projectedFieldIndexes)
-                  .mapToObj(columnHandleInternals::get)
-                  .collect(Collectors.toList()),
-              Optional.empty(),
-              Optional.ofNullable(timestamp),
-              Optional.of(limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit));
-      cursor = recordSetInternal.cursor();
+      List<ColumnHandleInternal> columns = Arrays.stream(projectedFieldIndexes)
+          .mapToObj(columnHandleInternals::get)
+          .collect(Collectors.toList());
+      cursor = RecordSetInternal
+          .builder(clientSession, splitInternals, columns)
+          .withExpression(null)
+          .withTimestamp(timestamp)
+          .withLimit(limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit)
+          .withQueryHandle(false)
+          .build()
+          .cursor();
     }
     if (!cursor.advanceNextPosition()) {
       return false;

--- a/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBRecordReader.java
+++ b/mapreduce/mapreduce-base/src/main/java/io/tidb/bigdata/mapreduce/tidb/TiDBRecordReader.java
@@ -111,17 +111,18 @@ public class TiDBRecordReader<T extends TiDBWritable> extends RecordReader<LongW
       key = new LongWritable();
     }
     if (cursor == null) {
-      List<ColumnHandleInternal> columns = Arrays.stream(projectedFieldIndexes)
-          .mapToObj(columnHandleInternals::get)
-          .collect(Collectors.toList());
-      cursor = RecordSetInternal
-          .builder(clientSession, splitInternals, columns)
-          .withExpression(null)
-          .withTimestamp(timestamp)
-          .withLimit(limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit)
-          .withQueryHandle(false)
-          .build()
-          .cursor();
+      List<ColumnHandleInternal> columns =
+          Arrays.stream(projectedFieldIndexes)
+              .mapToObj(columnHandleInternals::get)
+              .collect(Collectors.toList());
+      cursor =
+          RecordSetInternal.builder(clientSession, splitInternals, columns)
+              .withExpression(null)
+              .withTimestamp(timestamp)
+              .withLimit(limit > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) limit)
+              .withQueryHandle(false)
+              .build()
+              .cursor();
     }
     if (!cursor.advanceNextPosition()) {
       return false;

--- a/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
+++ b/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.mapreduce.Job;

--- a/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
+++ b/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
@@ -29,6 +29,7 @@ import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.SplitInternal;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -172,13 +173,10 @@ public class MapReduceTest {
   @Test
   public void testReadRecords() throws Exception {
     ClientSession clientSession = getSingleConnection();
-    TableHandleInternal tableHandleInternal =
-        new TableHandleInternal(UUID.randomUUID().toString(), DATABASE_NAME, TABLE_NAME);
+    TiTableInfo tiTableInfo = clientSession.getTableMust(DATABASE_NAME, TABLE_NAME);
+    TableHandleInternal tableHandleInternal = new TableHandleInternal(DATABASE_NAME, tiTableInfo);
     List<SplitInternal> splitInternals = clientSession.getSplits(tableHandleInternal);
-    List<ColumnHandleInternal> columnHandleInternals =
-        clientSession
-            .getTableColumns(tableHandleInternal)
-            .orElseThrow(() -> new NullPointerException("columnHandleInternals is null"));
+    List<ColumnHandleInternal> columnHandleInternals = ClientSession.getTableColumns(tiTableInfo);
 
     for (SplitInternal splitInternal : splitInternals) {
       List<ColumnHandleInternal> columns =

--- a/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
+++ b/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
@@ -27,7 +27,6 @@ import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.RecordCursorInternal;
 import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.SplitInternal;
-import io.tidb.bigdata.tidb.SplitManagerInternal;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
 import java.io.IOException;
@@ -175,8 +174,7 @@ public class MapReduceTest {
     ClientSession clientSession = getSingleConnection();
     TableHandleInternal tableHandleInternal =
         new TableHandleInternal(UUID.randomUUID().toString(), DATABASE_NAME, TABLE_NAME);
-    SplitManagerInternal splitManagerInternal = new SplitManagerInternal(clientSession);
-    List<SplitInternal> splitInternals = splitManagerInternal.getSplits(tableHandleInternal);
+    List<SplitInternal> splitInternals = clientSession.getSplits(tableHandleInternal);
     List<ColumnHandleInternal> columnHandleInternals =
         clientSession
             .getTableColumns(tableHandleInternal)

--- a/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
+++ b/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -184,17 +183,18 @@ public class MapReduceTest {
             .orElseThrow(() -> new NullPointerException("columnHandleInternals is null"));
 
     for (SplitInternal splitInternal : splitInternals) {
-      List<ColumnHandleInternal> columns = Arrays.stream(IntStream.range(0, 29).toArray())
-          .mapToObj(columnHandleInternals::get)
-          .collect(Collectors.toList());
-      RecordCursorInternal cursor = RecordSetInternal
-          .builder(clientSession, ImmutableList.of(splitInternal), columns)
-          .withExpression(null)
-          .withTimestamp(null)
-          .withLimit(null)
-          .withQueryHandle(false)
-          .build()
-          .cursor();
+      List<ColumnHandleInternal> columns =
+          Arrays.stream(IntStream.range(0, 29).toArray())
+              .mapToObj(columnHandleInternals::get)
+              .collect(Collectors.toList());
+      RecordCursorInternal cursor =
+          RecordSetInternal.builder(clientSession, ImmutableList.of(splitInternal), columns)
+              .withExpression(null)
+              .withTimestamp(null)
+              .withLimit(null)
+              .withQueryHandle(false)
+              .build()
+              .cursor();
       cursor.advanceNextPosition();
       TiDBResultSet tiDBResultSet = new TiDBResultSet(cursor.fieldCount(), null);
       for (int index = 0; index < cursor.fieldCount(); index++) {

--- a/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
+++ b/mapreduce/mapreduce-base/src/test/java/io/tidb/bigdata/mapreduce/tidb/MapReduceTest.java
@@ -18,6 +18,7 @@ package io.tidb.bigdata.mapreduce.tidb;
 
 import static java.lang.String.format;
 
+import com.google.common.collect.ImmutableList;
 import io.tidb.bigdata.mapreduce.tidb.example.TiDBMapreduceDemo;
 import io.tidb.bigdata.test.ConfigUtils;
 import io.tidb.bigdata.test.IntegrationTest;
@@ -183,17 +184,17 @@ public class MapReduceTest {
             .orElseThrow(() -> new NullPointerException("columnHandleInternals is null"));
 
     for (SplitInternal splitInternal : splitInternals) {
-      RecordSetInternal recordSetInternal =
-          new RecordSetInternal(
-              clientSession,
-              splitInternal,
-              Arrays.stream(IntStream.range(0, 29).toArray())
-                  .mapToObj(columnHandleInternals::get)
-                  .collect(Collectors.toList()),
-              Optional.empty(),
-              Optional.empty(),
-              Optional.of(Integer.MAX_VALUE));
-      RecordCursorInternal cursor = recordSetInternal.cursor();
+      List<ColumnHandleInternal> columns = Arrays.stream(IntStream.range(0, 29).toArray())
+          .mapToObj(columnHandleInternals::get)
+          .collect(Collectors.toList());
+      RecordCursorInternal cursor = RecordSetInternal
+          .builder(clientSession, ImmutableList.of(splitInternal), columns)
+          .withExpression(null)
+          .withTimestamp(null)
+          .withLimit(null)
+          .withQueryHandle(false)
+          .build()
+          .cursor();
       cursor.advanceNextPosition();
       TiDBResultSet tiDBResultSet = new TiDBResultSet(cursor.fieldCount(), null);
       for (int index = 0; index < cursor.fieldCount(); index++) {

--- a/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBMetadata.java
+++ b/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBMetadata.java
@@ -122,7 +122,8 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
         new SchemaTableName(schemaName, tableName),
         getTableMetadataStream(tableHandle).collect(toImmutableList()),
         ImmutableMap.of(
-            PRIMARY_KEY, join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
+            PRIMARY_KEY,
+            join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
             UNIQUE_KEY,
             getInternal().getUniqueKeyColumns(schemaName, tableName).stream()
                 .flatMap(List::stream)
@@ -166,8 +167,8 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
   public Map<String, ColumnHandle> getColumnHandles(
       ConnectorSession session, ConnectorTableHandle tableHandle) {
     TiDBTableHandle handle = (TiDBTableHandle) tableHandle;
-    return getColumnHandlesStream(handle).collect(
-        toImmutableMap(TiDBColumnHandle::getName, identity()));
+    return getColumnHandlesStream(handle)
+        .collect(toImmutableMap(TiDBColumnHandle::getName, identity()));
   }
 
   @Override

--- a/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBRecordSet.java
+++ b/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBRecordSet.java
@@ -22,6 +22,7 @@ import static io.tidb.bigdata.prestodb.tidb.TiDBColumnHandle.internalHandles;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 import io.tidb.bigdata.tidb.Expressions;
 import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.Wrapper;
@@ -40,12 +41,15 @@ public final class TiDBRecordSet extends Wrapper<RecordSetInternal> implements R
       List<TiDBColumnHandle> columnHandles,
       Optional<TiTimestamp> timestamp) {
     super(
-        new RecordSetInternal(
-            session.getInternal(),
-            split.toInternal(),
-            internalHandles(columnHandles),
-            split.getAdditionalPredicate().map(Expressions::deserialize),
-            timestamp));
+        RecordSetInternal.builder(session.getInternal(), ImmutableList.of(split.toInternal()),
+                internalHandles(columnHandles))
+            .withExpression(
+                split.getAdditionalPredicate().map(Expressions::deserialize).orElse(null))
+            .withTimestamp(timestamp.orElse(null))
+            .withLimit(null)
+            .withQueryHandle(false)
+            .build());
+
     this.columnHandles = columnHandles;
     this.columnTypes =
         columnHandles.stream().map(TiDBColumnHandle::getPrestoType).collect(toImmutableList());

--- a/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBRecordSet.java
+++ b/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBRecordSet.java
@@ -41,7 +41,9 @@ public final class TiDBRecordSet extends Wrapper<RecordSetInternal> implements R
       List<TiDBColumnHandle> columnHandles,
       Optional<TiTimestamp> timestamp) {
     super(
-        RecordSetInternal.builder(session.getInternal(), ImmutableList.of(split.toInternal()),
+        RecordSetInternal.builder(
+                session.getInternal(),
+                ImmutableList.of(split.toInternal()),
                 internalHandles(columnHandles))
             .withExpression(
                 split.getAdditionalPredicate().map(Expressions::deserialize).orElse(null))

--- a/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBTableHandle.java
+++ b/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBTableHandle.java
@@ -31,8 +31,9 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
   public TiDBTableHandle(
       @JsonProperty("connectorId") String connectorId,
       @JsonProperty("schemaName") String schemaName,
-      @JsonProperty("tableName") String tableName) {
-    super(new TableHandleInternal(connectorId, schemaName, tableName));
+      @JsonProperty("tiTableInfoBase64String") String tiTableInfoBase64String) {
+    super(new TableHandleInternal(connectorId, schemaName,
+        TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
   }
 
   TiDBTableHandle(TableHandleInternal internal) {

--- a/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBTableHandle.java
+++ b/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBTableHandle.java
@@ -32,8 +32,11 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
       @JsonProperty("connectorId") String connectorId,
       @JsonProperty("schemaName") String schemaName,
       @JsonProperty("tiTableInfoBase64String") String tiTableInfoBase64String) {
-    super(new TableHandleInternal(connectorId, schemaName,
-        TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
+    super(
+        new TableHandleInternal(
+            connectorId,
+            schemaName,
+            TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
   }
 
   TiDBTableHandle(TableHandleInternal internal) {

--- a/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBTableHandle.java
+++ b/prestodb/src/main/java/io/tidb/bigdata/prestodb/tidb/TiDBTableHandle.java
@@ -57,4 +57,9 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
   public String getTableName() {
     return getInternal().getTableName();
   }
+
+  @JsonProperty
+  public String getTiTableInfoBase64String() {
+    return getInternal().getTiTableInfoBase64String();
+  }
 }

--- a/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBMetadata.java
+++ b/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBMetadata.java
@@ -103,7 +103,8 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
         new SchemaTableName(schemaName, tableName),
         getTableMetadataStream(tableHandle).collect(toImmutableList()),
         ImmutableMap.of(
-            PRIMARY_KEY, join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
+            PRIMARY_KEY,
+            join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
             UNIQUE_KEY,
             getInternal().getUniqueKeyColumns(schemaName, tableName).stream()
                 .flatMap(List::stream)
@@ -149,8 +150,8 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
   public Map<String, ColumnHandle> getColumnHandles(
       ConnectorSession session, ConnectorTableHandle tableHandle) {
     TiDBTableHandle handle = (TiDBTableHandle) tableHandle;
-    return getColumnHandlesStream(handle).collect(
-        toImmutableMap(TiDBColumnHandle::getName, identity()));
+    return getColumnHandlesStream(handle)
+        .collect(toImmutableMap(TiDBColumnHandle::getName, identity()));
   }
 
   @Override

--- a/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBMetadata.java
+++ b/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBMetadata.java
@@ -93,19 +93,21 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
     checkArgument(
         tableHandle.getConnectorId().equals(getInternal().getConnectorId()),
         "tableHandle is not for this connector");
-    return getTableMetadata(tableHandle.getSchemaName(), tableHandle.getTableName());
+    return getTableMetadata(tableHandle);
   }
 
-  private ConnectorTableMetadata getTableMetadata(String schemaName, String tableName) {
+  private ConnectorTableMetadata getTableMetadata(TiDBTableHandle tableHandle) {
+    String schemaName = tableHandle.getSchemaName();
+    String tableName = tableHandle.getTableName();
     return new ConnectorTableMetadata(
         new SchemaTableName(schemaName, tableName),
-        getTableMetadataStream(schemaName, tableName).collect(toImmutableList()),
+        getTableMetadataStream(tableHandle).collect(toImmutableList()),
         ImmutableMap.of(
             PRIMARY_KEY, join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
             UNIQUE_KEY,
-                getInternal().getUniqueKeyColumns(schemaName, tableName).stream()
-                    .flatMap(List::stream)
-                    .collect(Collectors.joining(","))));
+            getInternal().getUniqueKeyColumns(schemaName, tableName).stream()
+                .flatMap(List::stream)
+                .collect(Collectors.joining(","))));
   }
 
   @Override
@@ -132,9 +134,9 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
         .orElse(tables);
   }
 
-  private Stream<TiDBColumnHandle> getColumnHandlesStream(String schemaName, String tableName) {
+  private Stream<TiDBColumnHandle> getColumnHandlesStream(TiDBTableHandle tableHandle) {
     return getInternal()
-        .getColumnHandles(schemaName, tableName)
+        .getColumnHandles(tableHandle.getInternal())
         .map(
             handles ->
                 handles.stream()
@@ -147,8 +149,8 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
   public Map<String, ColumnHandle> getColumnHandles(
       ConnectorSession session, ConnectorTableHandle tableHandle) {
     TiDBTableHandle handle = (TiDBTableHandle) tableHandle;
-    return getColumnHandlesStream(handle.getSchemaName(), handle.getTableName())
-        .collect(toImmutableMap(TiDBColumnHandle::getName, identity()));
+    return getColumnHandlesStream(handle).collect(
+        toImmutableMap(TiDBColumnHandle::getName, identity()));
   }
 
   @Override
@@ -157,17 +159,14 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
     requireNonNull(prefix, "prefix is null");
     ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
     for (SchemaTableName tableName : listTables(session, prefix)) {
-      columns.put(tableName, getTableMetadataStream(tableName).collect(toImmutableList()));
+      TiDBTableHandle tableHandle = getTableHandle(session, tableName);
+      columns.put(tableName, getTableMetadataStream(tableHandle).collect(toImmutableList()));
     }
     return columns.build();
   }
 
-  private Stream<ColumnMetadata> getTableMetadataStream(SchemaTableName schemaTable) {
-    return getTableMetadataStream(schemaTable.getSchemaName(), schemaTable.getTableName());
-  }
-
-  private Stream<ColumnMetadata> getTableMetadataStream(String schemaName, String tableName) {
-    return getColumnHandlesStream(schemaName, tableName).map(TiDBMetadata::createColumnMetadata);
+  private Stream<ColumnMetadata> getTableMetadataStream(TiDBTableHandle tableHandle) {
+    return getColumnHandlesStream(tableHandle).map(TiDBMetadata::createColumnMetadata);
   }
 
   @Override

--- a/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBRecordSet.java
+++ b/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBRecordSet.java
@@ -41,7 +41,9 @@ public final class TiDBRecordSet extends Wrapper<RecordSetInternal> implements R
       List<TiDBColumnHandle> columnHandles,
       Optional<TiTimestamp> timestamp) {
     super(
-        RecordSetInternal.builder(session.getInternal(), ImmutableList.of(split.toInternal()),
+        RecordSetInternal.builder(
+                session.getInternal(),
+                ImmutableList.of(split.toInternal()),
                 internalHandles(columnHandles))
             .withExpression(
                 split.getAdditionalPredicate().map(Expressions::deserialize).orElse(null))

--- a/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBTableHandle.java
+++ b/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBTableHandle.java
@@ -31,8 +31,9 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
   public TiDBTableHandle(
       @JsonProperty("connectorId") String connectorId,
       @JsonProperty("schemaName") String schemaName,
-      @JsonProperty("tableName") String tableName) {
-    super(new TableHandleInternal(connectorId, schemaName, tableName));
+      @JsonProperty("tiTableInfoBase64String") String tiTableInfoBase64String) {
+    super(new TableHandleInternal(connectorId, schemaName,
+        TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
   }
 
   TiDBTableHandle(TableHandleInternal internal) {

--- a/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBTableHandle.java
+++ b/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBTableHandle.java
@@ -32,8 +32,11 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
       @JsonProperty("connectorId") String connectorId,
       @JsonProperty("schemaName") String schemaName,
       @JsonProperty("tiTableInfoBase64String") String tiTableInfoBase64String) {
-    super(new TableHandleInternal(connectorId, schemaName,
-        TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
+    super(
+        new TableHandleInternal(
+            connectorId,
+            schemaName,
+            TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
   }
 
   TiDBTableHandle(TableHandleInternal internal) {

--- a/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBTableHandle.java
+++ b/prestosql/src/main/java/io/tidb/bigdata/prestosql/tidb/TiDBTableHandle.java
@@ -57,4 +57,9 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
   public String getTableName() {
     return getInternal().getTableName();
   }
+
+  @JsonProperty
+  public String getTiTableInfoBase64String() {
+    return getInternal().getTiTableInfoBase64String();
+  }
 }

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/ClientSession.java
@@ -54,7 +54,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -215,23 +214,11 @@ public final class ClientSession implements AutoCloseable {
   }
 
   public static List<ColumnHandleInternal> getTableColumns(
-      TiTableInfo table, Stream<String> columns) {
-    return selectColumns(getTableColumns(table), columns);
-  }
-
-  public static List<ColumnHandleInternal> getTableColumns(
-      TiTableInfo table, List<String> columns) {
-    if (columns.size() == 0) {
-      throw new IllegalArgumentException("Columns can not be empty");
+      TiTableInfo table, List<String> selectedColumns) {
+    if (selectedColumns.size() == 0) {
+      throw new IllegalArgumentException("SelectedColumns can not be empty");
     }
-    return selectColumns(getTableColumns(table), columns.stream());
-  }
-
-  public static List<ColumnHandleInternal> getTableColumns(TiTableInfo table, String[] columns) {
-    if (columns.length == 0) {
-      throw new IllegalArgumentException("Columns can not be empty");
-    }
-    return selectColumns(getTableColumns(table), Arrays.stream(columns));
+    return selectColumns(getTableColumns(table), selectedColumns.stream());
   }
 
   private List<RangeSplitter.RegionTask> getRangeRegionTasks(

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/MetadataInternal.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/MetadataInternal.java
@@ -44,7 +44,7 @@ public final class MetadataInternal {
   public Optional<TableHandleInternal> getTableHandle(String schemaName, String tableName) {
     return session
         .getTable(schemaName, tableName)
-        .map(t -> new TableHandleInternal(connectorId, schemaName, tableName));
+        .map(tiTableInfo -> new TableHandleInternal(connectorId, schemaName, tiTableInfo));
   }
 
   public Map<String, List<String>> listTables(Optional<String> schemaName) {
@@ -52,12 +52,7 @@ public final class MetadataInternal {
   }
 
   public Optional<List<ColumnHandleInternal>> getColumnHandles(TableHandleInternal tableHandle) {
-    return session.getTableColumns(tableHandle);
-  }
-
-  public Optional<List<ColumnHandleInternal>> getColumnHandles(
-      String schemaName, String tableName) {
-    return session.getTableColumns(schemaName, tableName);
+    return Optional.of(ClientSession.getTableColumns(tableHandle.getTiTableInfo()));
   }
 
   public boolean tableExists(String databaseName, String tableName) {

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/RecordSetInternal.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/RecordSetInternal.java
@@ -17,101 +17,56 @@
 package io.tidb.bigdata.tidb;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import io.tidb.bigdata.tidb.expression.Expression;
 import io.tidb.bigdata.tidb.handle.ColumnHandleInternal;
 import io.tidb.bigdata.tidb.key.Base64KeyRange;
 import io.tidb.bigdata.tidb.meta.TiDAGRequest;
-import io.tidb.bigdata.tidb.meta.TiDAGRequest.Builder;
 import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import io.tidb.bigdata.tidb.operation.iterator.CoprocessorIterator;
 import io.tidb.bigdata.tidb.row.Row;
 import io.tidb.bigdata.tidb.types.DataType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.tikv.common.meta.TiTimestamp;
 
 public final class RecordSetInternal {
 
   private final ClientSession session;
   private final List<SplitInternal> splits;
-  private final List<Base64KeyRange> ranges;
-  private final boolean queryHandle;
   private final List<ColumnHandleInternal> columnHandles;
+  private final Expression expression;
+  private final TiTimestamp timestamp;
+  private final Integer limit;
+  private final boolean queryHandle;
+
   private final List<DataType> columnTypes;
-  private final Supplier<RowHandleIterator> iteratorSupplier;
 
-  public RecordSetInternal(
-      ClientSession session,
-      SplitInternal split,
-      List<ColumnHandleInternal> columnHandles,
-      Optional<Expression> expression,
-      Optional<TiTimestamp> timestamp) {
-    this(session, ImmutableList.of(split), columnHandles, expression, timestamp, Optional.empty());
-  }
-
-  public RecordSetInternal(
-      ClientSession session,
-      List<SplitInternal> splits,
-      List<ColumnHandleInternal> columnHandles,
-      Optional<Expression> expression,
-      Optional<TiTimestamp> timestamp) {
-    this(session, splits, columnHandles, expression, timestamp, Optional.empty());
-  }
-
-  public RecordSetInternal(
-      ClientSession session,
-      SplitInternal split,
-      List<ColumnHandleInternal> columnHandles,
-      Optional<Expression> expression,
-      Optional<TiTimestamp> timestamp,
-      Optional<Integer> limit) {
-    this(session, ImmutableList.of(split), columnHandles, expression, timestamp, limit);
-  }
-
-  public RecordSetInternal(
-      ClientSession session,
-      List<SplitInternal> splits,
-      List<ColumnHandleInternal> columnHandles,
-      Optional<Expression> expression,
-      Optional<TiTimestamp> timestamp,
-      Optional<Integer> limit) {
-    this(session, splits, columnHandles, expression, timestamp, limit, false);
-  }
-
-  public RecordSetInternal(
-      ClientSession session,
-      List<SplitInternal> splits,
-      List<ColumnHandleInternal> columnHandles,
-      Optional<Expression> expression,
-      Optional<TiTimestamp> timestamp,
-      Optional<Integer> limit,
+  private RecordSetInternal(
+      @Nonnull ClientSession session,
+      @Nonnull List<SplitInternal> splits,
+      @Nonnull List<ColumnHandleInternal> columnHandles,
+      Expression expression,
+      TiTimestamp timestamp,
+      Integer limit,
       boolean queryHandle) {
     this.session = session;
     this.splits = splits;
+    this.columnHandles = columnHandles;
+    this.expression = expression;
+    this.timestamp = timestamp;
+    this.limit = limit;
     this.queryHandle = queryHandle;
-    this.columnHandles = requireNonNull(columnHandles, "ColumnHandles can not be null");
     this.columnTypes =
         columnHandles.stream().map(ColumnHandleInternal::getType).collect(toImmutableList());
     checkSplits();
-    this.ranges =
-        splits.stream()
-            .map(
-                splitInternal ->
-                    new Base64KeyRange(splitInternal.getStartKey(), splitInternal.getEndKey()))
-            .collect(Collectors.toList());
-    this.iteratorSupplier = () -> iterator(expression, timestamp, limit);
   }
 
   private void checkSplits() {
-    Preconditions.checkArgument(
-        splits != null && splits.size() >= 1, "Splits can not be empty or null");
+    Preconditions.checkArgument(splits.size() >= 1, "Splits can not be empty");
     Preconditions.checkArgument(
         splits.stream().map(SplitInternal::getTimestamp).distinct().count() == 1,
         "Timestamp for splits must be equals");
@@ -120,40 +75,45 @@ public final class RecordSetInternal {
         "Table for splits must be equals");
   }
 
-  public List<DataType> getColumnTypes() {
-    return columnTypes;
-  }
-
-  public RecordCursorInternal cursor() {
-    return new RecordCursorInternal(columnHandles, iteratorSupplier.get());
-  }
-
-  private TiDAGRequest.Builder buildRequest(
-      List<String> columns,
-      Optional<Expression> expression,
-      Optional<TiTimestamp> timestamp,
-      Optional<Integer> limit) {
+  private TiDAGRequest.Builder buildRequest(List<String> columns) {
     SplitInternal split = splits.get(0);
     TiDAGRequest.Builder request = session.request(split.getTable(), columns);
-    limit.ifPresent(request::setLimit);
-    expression.ifPresent(request::addFilter);
-    request.setStartTs(split.getTimestamp());
-    timestamp.ifPresent(request::setStartTs);
+    if (limit != null) {
+      request.setLimit(limit);
+    }
+    if (expression != null) {
+      request.addFilter(expression);
+    }
+    if (timestamp != null) {
+      request.setStartTs(timestamp);
+    } else {
+      request.setStartTs(split.getTimestamp());
+    }
     return request;
   }
 
-  private RowHandleIterator iterator(
-      Optional<Expression> expression, Optional<TiTimestamp> timestamp, Optional<Integer> limit) {
+  public RecordCursorInternal cursor() {
+    return new RecordCursorInternal(columnHandles, iterator());
+  }
+
+  private RowHandleIterator iterator() {
     SplitInternal split = splits.get(0);
     List<String> columns =
         columnHandles.stream().map(ColumnHandleInternal::getName).collect(toImmutableList());
+    List<Base64KeyRange> ranges =
+        splits.stream()
+            .map(
+                splitInternal ->
+                    new Base64KeyRange(splitInternal.getStartKey(), splitInternal.getEndKey()))
+            .collect(Collectors.toList());
+
     // Whether generate handle for each tidb row, there are two cases:
     // 1. _tidb_rowid in table columns, handle is the value of _tidb_rowid;
     // 2. table is pk handle or common handle, we will recalculate handle by primary key.
     // If query handle is true, we should add primary key columns or _tidb_rowid into query columns
     // because column pruning may remove these columns.
     if (!queryHandle) {
-      Builder request = buildRequest(columns, expression, timestamp, limit);
+      TiDAGRequest.Builder request = buildRequest(columns);
       return RowHandleIterator.createWrap(session.iterate(request, ranges));
     } else {
       TiTableInfo tiTableInfo =
@@ -176,9 +136,63 @@ public final class RecordSetInternal {
           queryColumns.add(ClientSession.TIDB_ROW_ID_COLUMN_NAME);
         }
       }
-      Builder request = buildRequest(queryColumns, expression, timestamp, limit);
+      TiDAGRequest.Builder request = buildRequest(queryColumns);
       CoprocessorIterator<Row> iterate = session.iterate(request, ranges);
       return RowHandleIterator.create(tiTableInfo, columns, queryColumns, iterate);
+    }
+  }
+
+  public List<DataType> getColumnTypes() {
+    return columnTypes;
+  }
+
+  public static Builder builder(
+      ClientSession session, List<SplitInternal> splits, List<ColumnHandleInternal> columnHandles) {
+    return new Builder(session, splits, columnHandles);
+  }
+
+  public static final class Builder {
+
+    private final ClientSession session;
+    private final List<SplitInternal> splits;
+    private List<ColumnHandleInternal> columnHandles;
+    private Expression expression;
+    private TiTimestamp timestamp;
+    private Integer limit;
+    private boolean queryHandle;
+
+    private Builder(
+        @Nonnull ClientSession session,
+        @Nonnull List<SplitInternal> splits,
+        @Nonnull List<ColumnHandleInternal> columnHandles) {
+      this.session = session;
+      this.splits = splits;
+      this.columnHandles = columnHandles;
+    }
+
+    public Builder withExpression(Expression expression) {
+      this.expression = expression;
+      return this;
+    }
+
+    public Builder withTimestamp(TiTimestamp timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public Builder withLimit(Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder withQueryHandle(boolean queryHandle) {
+      this.queryHandle = queryHandle;
+      return this;
+    }
+
+    public RecordSetInternal build() {
+      return new RecordSetInternal(
+          session, splits, columnHandles, expression, timestamp, limit, queryHandle);
     }
   }
 }

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/SplitManagerInternal.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/SplitManagerInternal.java
@@ -18,11 +18,8 @@ package io.tidb.bigdata.tidb;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toCollection;
 
 import io.tidb.bigdata.tidb.handle.TableHandleInternal;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,21 +36,11 @@ public final class SplitManagerInternal {
   }
 
   public List<SplitInternal> getSplits(TableHandleInternal tableHandle) {
-    return getSplits(tableHandle, session.getSnapshotVersion());
+    return session.getSplits(tableHandle);
   }
 
   public List<SplitInternal> getSplits(TableHandleInternal tableHandle, TiTimestamp timestamp) {
-    List<SplitInternal> splits =
-        session.getTableRanges(tableHandle).stream()
-            .map(range -> new SplitInternal(tableHandle, range, timestamp))
-            .collect(toCollection(ArrayList::new));
-    Collections.shuffle(splits);
-    LOG.info(
-        "The number of split for table `{}`.`{}` is {}",
-        tableHandle.getSchemaName(),
-        tableHandle.getTableName(),
-        splits.size());
-    return Collections.unmodifiableList(splits);
+    return session.getSplits(tableHandle, timestamp);
   }
 
   @Override

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/handle/TableHandleInternal.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/handle/TableHandleInternal.java
@@ -39,7 +39,6 @@ public class TableHandleInternal implements Serializable {
   // If we need to encode TiTableInfo to json, we could use base64 to encode it,
   // since TiTableInfo use tikv shaded jackson package and can not import jackson time module.
   // Otherwise, ignore this field.
-  // TODO: use it in Presto/Trino API.
   private final String tiTableInfoBase64String;
 
   public TableHandleInternal(String connectorId, String schemaName, TiTableInfo tiTableInfo) {

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/handle/TableHandleInternal.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/handle/TableHandleInternal.java
@@ -20,19 +20,47 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Joiner;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Base64;
 import java.util.Objects;
+import java.util.Optional;
 
 public class TableHandleInternal implements Serializable {
 
   private final String connectorId;
   private final String schemaName;
+  private final TiTableInfo tiTableInfo;
   private final String tableName;
+  // If we need to encode TiTableInfo to json, we could use base64 to encode it,
+  // since TiTableInfo use tikv shaded jackson package and can not import jackson time module.
+  // Otherwise, ignore this field.
+  // TODO: use it in Presto/Trino API.
+  private final String tiTableInfoBase64String;
 
   public TableHandleInternal(String connectorId, String schemaName, String tableName) {
     this.connectorId = requireNonNull(connectorId, "connectorId is null");
     this.schemaName = requireNonNull(schemaName, "schemaName is null");
     this.tableName = requireNonNull(tableName, "tableName is null");
+    this.tiTableInfoBase64String = null;
+    this.tiTableInfo = null;
+  }
+
+  public TableHandleInternal(String connectorId, String schemaName, TiTableInfo tiTableInfo) {
+    this.connectorId = requireNonNull(connectorId, "connectorId is null");
+    this.schemaName = requireNonNull(schemaName, "schemaName is null");
+    this.tiTableInfo = requireNonNull(tiTableInfo, "tiTableInfo can not be null");
+    this.tableName = tiTableInfo.getName();
+    this.tiTableInfoBase64String = encodeTiTableInfo(tiTableInfo);
+  }
+
+  public TableHandleInternal(String schemaName, TiTableInfo tiTableInfo) {
+    this("", schemaName, tiTableInfo);
   }
 
   public String getSchemaTableName() {
@@ -49,6 +77,22 @@ public class TableHandleInternal implements Serializable {
 
   public String getTableName() {
     return tableName;
+  }
+
+  public Optional<TiTableInfo> getTiTableInfo() {
+    return Optional.ofNullable(tiTableInfo);
+  }
+
+  public TiTableInfo getTiTableInfoMust() {
+    return Objects.requireNonNull(tiTableInfo, "tiTableInfo is null");
+  }
+
+  public Optional<String> getTiTableInfoBase64String() {
+    return Optional.ofNullable(tiTableInfoBase64String);
+  }
+
+  public String getTiTableInfoBase64StringMust() {
+    return Objects.requireNonNull(tiTableInfoBase64String, "tiTableInfoBase64String is null");
   }
 
   @Override
@@ -78,5 +122,25 @@ public class TableHandleInternal implements Serializable {
         .add("schema", schemaName)
         .add("table", tableName)
         .toString();
+  }
+
+  public static String encodeTiTableInfo(TiTableInfo tiTableInfo) {
+    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+      objectOutputStream.writeObject(tiTableInfo);
+      return Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray());
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static TiTableInfo decodeTiTableInfo(String base64String) {
+    try (ByteArrayInputStream byteArrayInputStream =
+            new ByteArrayInputStream(Base64.getDecoder().decode(base64String));
+        ObjectInputStream objectOutputStream = new ObjectInputStream(byteArrayInputStream)) {
+      return (TiTableInfo) objectOutputStream.readObject();
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/handle/TableHandleInternal.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/handle/TableHandleInternal.java
@@ -29,7 +29,6 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Base64;
 import java.util.Objects;
-import java.util.Optional;
 
 public class TableHandleInternal implements Serializable {
 
@@ -42,14 +41,6 @@ public class TableHandleInternal implements Serializable {
   // Otherwise, ignore this field.
   // TODO: use it in Presto/Trino API.
   private final String tiTableInfoBase64String;
-
-  public TableHandleInternal(String connectorId, String schemaName, String tableName) {
-    this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    this.schemaName = requireNonNull(schemaName, "schemaName is null");
-    this.tableName = requireNonNull(tableName, "tableName is null");
-    this.tiTableInfoBase64String = null;
-    this.tiTableInfo = null;
-  }
 
   public TableHandleInternal(String connectorId, String schemaName, TiTableInfo tiTableInfo) {
     this.connectorId = requireNonNull(connectorId, "connectorId is null");
@@ -79,20 +70,12 @@ public class TableHandleInternal implements Serializable {
     return tableName;
   }
 
-  public Optional<TiTableInfo> getTiTableInfo() {
-    return Optional.ofNullable(tiTableInfo);
+  public TiTableInfo getTiTableInfo() {
+    return tiTableInfo;
   }
 
-  public TiTableInfo getTiTableInfoMust() {
-    return Objects.requireNonNull(tiTableInfo, "tiTableInfo is null");
-  }
-
-  public Optional<String> getTiTableInfoBase64String() {
-    return Optional.ofNullable(tiTableInfoBase64String);
-  }
-
-  public String getTiTableInfoBase64StringMust() {
-    return Objects.requireNonNull(tiTableInfoBase64String, "tiTableInfoBase64String is null");
+  public String getTiTableInfoBase64String() {
+    return tiTableInfoBase64String;
   }
 
   @Override

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/allocator/RowIDAllocatorTest.java
@@ -21,6 +21,7 @@ import io.tidb.bigdata.tidb.ClientConfig;
 import io.tidb.bigdata.tidb.ClientSession;
 import io.tidb.bigdata.tidb.ConfigUtils;
 import io.tidb.bigdata.tidb.allocator.DynamicRowIDAllocator.RowIDAllocatorType;
+import io.tidb.bigdata.tidb.meta.TiTableInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -91,12 +92,14 @@ public class RowIDAllocatorTest {
       session.sqlUpdate(
           String.format("DROP TABLE IF EXISTS `%s`.`%s`", databaseName, tableName),
           String.format(createTableSql, databaseName, tableName));
+
+      TiTableInfo tiTableInfo = session.getTableMust(databaseName, tableName);
       List<FutureTask<RowIDAllocator>> tasks = new ArrayList<>();
 
       for (int i = 1; i <= count; i++) {
         FutureTask<RowIDAllocator> task =
             new FutureTask<>(
-                () -> session.createRowIdAllocator(databaseName, tableName, step, type));
+                () -> session.createRowIdAllocator(databaseName, tiTableInfo, step, type));
         tasks.add(task);
         executorService.submit(task);
       }

--- a/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBMetadata.java
+++ b/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBMetadata.java
@@ -93,19 +93,22 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
     checkArgument(
         tableHandle.getConnectorId().equals(getInternal().getConnectorId()),
         "tableHandle is not for this connector");
-    return getTableMetadata(tableHandle.getSchemaName(), tableHandle.getTableName());
+    return getTableMetadata(tableHandle);
   }
 
-  private ConnectorTableMetadata getTableMetadata(String schemaName, String tableName) {
+  private ConnectorTableMetadata getTableMetadata(TiDBTableHandle tableHandle) {
+    String schemaName = tableHandle.getSchemaName();
+    String tableName = tableHandle.getTableName();
     return new ConnectorTableMetadata(
         new SchemaTableName(schemaName, tableName),
-        getTableMetadataStream(schemaName, tableName).collect(toImmutableList()),
+        getTableMetadataStream(tableHandle).collect(toImmutableList()),
         ImmutableMap.of(
-            PRIMARY_KEY, join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
+            PRIMARY_KEY,
+            join(",", getInternal().getPrimaryKeyColumns(schemaName, tableName)),
             UNIQUE_KEY,
-                getInternal().getUniqueKeyColumns(schemaName, tableName).stream()
-                    .flatMap(List::stream)
-                    .collect(Collectors.joining(","))));
+            getInternal().getUniqueKeyColumns(schemaName, tableName).stream()
+                .flatMap(List::stream)
+                .collect(Collectors.joining(","))));
   }
 
   @Override
@@ -132,9 +135,9 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
         .orElse(tables);
   }
 
-  private Stream<TiDBColumnHandle> getColumnHandlesStream(String schemaName, String tableName) {
+  private Stream<TiDBColumnHandle> getColumnHandlesStream(TiDBTableHandle tableHandle) {
     return getInternal()
-        .getColumnHandles(schemaName, tableName)
+        .getColumnHandles(tableHandle.getInternal())
         .map(
             handles ->
                 handles.stream()
@@ -147,7 +150,7 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
   public Map<String, ColumnHandle> getColumnHandles(
       ConnectorSession session, ConnectorTableHandle tableHandle) {
     TiDBTableHandle handle = (TiDBTableHandle) tableHandle;
-    return getColumnHandlesStream(handle.getSchemaName(), handle.getTableName())
+    return getColumnHandlesStream(handle)
         .collect(toImmutableMap(TiDBColumnHandle::getName, identity()));
   }
 
@@ -157,17 +160,14 @@ public final class TiDBMetadata extends Wrapper<MetadataInternal> implements Con
     requireNonNull(prefix, "prefix is null");
     ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
     for (SchemaTableName tableName : listTables(session, prefix)) {
-      columns.put(tableName, getTableMetadataStream(tableName).collect(toImmutableList()));
+      TiDBTableHandle tableHandle = getTableHandle(session, tableName);
+      columns.put(tableName, getTableMetadataStream(tableHandle).collect(toImmutableList()));
     }
     return columns.build();
   }
 
-  private Stream<ColumnMetadata> getTableMetadataStream(SchemaTableName schemaTable) {
-    return getTableMetadataStream(schemaTable.getSchemaName(), schemaTable.getTableName());
-  }
-
-  private Stream<ColumnMetadata> getTableMetadataStream(String schemaName, String tableName) {
-    return getColumnHandlesStream(schemaName, tableName).map(TiDBMetadata::createColumnMetadata);
+  private Stream<ColumnMetadata> getTableMetadataStream(TiDBTableHandle tableHandle) {
+    return getColumnHandlesStream(tableHandle).map(TiDBMetadata::createColumnMetadata);
   }
 
   @Override

--- a/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBRecordSet.java
+++ b/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBRecordSet.java
@@ -19,6 +19,7 @@ package io.tidb.bigdata.trino.tidb;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.tidb.bigdata.trino.tidb.TiDBColumnHandle.internalHandles;
 
+import com.google.common.collect.ImmutableList;
 import io.tidb.bigdata.tidb.Expressions;
 import io.tidb.bigdata.tidb.RecordSetInternal;
 import io.tidb.bigdata.tidb.Wrapper;
@@ -40,12 +41,15 @@ public final class TiDBRecordSet extends Wrapper<RecordSetInternal> implements R
       List<TiDBColumnHandle> columnHandles,
       Optional<TiTimestamp> timestamp) {
     super(
-        new RecordSetInternal(
-            session.getInternal(),
-            split.toInternal(),
-            internalHandles(columnHandles),
-            split.getAdditionalPredicate().map(Expressions::deserialize),
-            timestamp));
+        RecordSetInternal.builder(session.getInternal(), ImmutableList.of(split.toInternal()),
+                internalHandles(columnHandles))
+            .withExpression(
+                split.getAdditionalPredicate().map(Expressions::deserialize).orElse(null))
+            .withTimestamp(timestamp.orElse(null))
+            .withLimit(null)
+            .withQueryHandle(false)
+            .build());
+
     this.columnHandles = columnHandles;
     this.columnTypes =
         columnHandles.stream().map(TiDBColumnHandle::getPrestoType).collect(toImmutableList());

--- a/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBRecordSet.java
+++ b/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBRecordSet.java
@@ -41,7 +41,9 @@ public final class TiDBRecordSet extends Wrapper<RecordSetInternal> implements R
       List<TiDBColumnHandle> columnHandles,
       Optional<TiTimestamp> timestamp) {
     super(
-        RecordSetInternal.builder(session.getInternal(), ImmutableList.of(split.toInternal()),
+        RecordSetInternal.builder(
+                session.getInternal(),
+                ImmutableList.of(split.toInternal()),
                 internalHandles(columnHandles))
             .withExpression(
                 split.getAdditionalPredicate().map(Expressions::deserialize).orElse(null))

--- a/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBTableHandle.java
+++ b/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBTableHandle.java
@@ -31,8 +31,12 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
   public TiDBTableHandle(
       @JsonProperty("connectorId") String connectorId,
       @JsonProperty("schemaName") String schemaName,
-      @JsonProperty("tableName") String tableName) {
-    super(new TableHandleInternal(connectorId, schemaName, tableName));
+      @JsonProperty("tiTableInfoBase64String") String tiTableInfoBase64String) {
+    super(
+        new TableHandleInternal(
+            connectorId,
+            schemaName,
+            TableHandleInternal.decodeTiTableInfo(tiTableInfoBase64String)));
   }
 
   TiDBTableHandle(TableHandleInternal internal) {

--- a/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBTableHandle.java
+++ b/trino/src/main/java/io/tidb/bigdata/trino/tidb/TiDBTableHandle.java
@@ -57,4 +57,9 @@ public final class TiDBTableHandle extends Wrapper<TableHandleInternal>
   public String getTableName() {
     return getInternal().getTableName();
   }
+
+  @JsonProperty
+  public String getTiTableInfoBase64String() {
+    return getInternal().getTiTableInfoBase64String();
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change
Reduce the number of RPC getTable calls.

## Brief change log
1. add a new field named titableinfo in `io.tidb.bigdata.tidb.handle.TableHandleInternal` to storead titableinfo, instead of querying it every time.
2. Add builder for `io.tidb.bigdata.tidb.RecordSetInternal`;
3. Move getSplit() method to ClientSession, we needn't SplitManager in flink/hive/mapreduce;
4. Reduce the number of RPC getTable calls;
5. Change a lot of methods parameters (String databaseName,String tableName) to (String databaseName,TiTableInfo tableInfo) in ClientSession.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API: no
- The runtime per-record code paths (performance sensitive): yes

## Documentation

- Does this pull request introduce a new feature? no
