### PR TITLE
bugfix: fix exception  Cannot parse "0000-00-00 00:00:00"

### DIFF
--- a/tidb/src/main/java/io/tidb/bigdata/tidb/meta/TiColumnInfo.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/meta/TiColumnInfo.java
@@ -215,7 +215,8 @@ public class TiColumnInfo implements Serializable {
     }
   }
 
-  private ByteString getOriginDefaultValueAsByteString() {
+  @VisibleForTesting
+  public ByteString getOriginDefaultValueAsByteString() {
     CodecDataOutput cdo = new CodecDataOutput();
     type.encode(
         cdo, EncodeType.VALUE, type.getOriginDefaultValue(getOriginDefaultValue(), version));

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/types/TimestampType.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/types/TimestampType.java
@@ -48,9 +48,7 @@ public class TimestampType extends AbstractDateTimeType {
 
   public static final MySQLType[] subTypes = new MySQLType[] {MySQLType.TypeTimestamp};
 
-  /**
-   * Default value for timestamp type is 0000-00-00 00:00:00
-   */
+  /** Default value for timestamp type is 0000-00-00 00:00:00 */
   public static final String TIMESTAMP_NULL_DEFAULT = "0000-00-00 00:00:00";
 
   TimestampType(MySQLType tp) {
@@ -97,7 +95,8 @@ public class TimestampType extends AbstractDateTimeType {
 
   @Override
   public Object getOriginDefaultValue(String value, long version) {
-    // avoid exception: org.joda.time.IllegalFieldValueException: Cannot parse "0000-00-00 00:00:00": Value 0 for monthOfYear must be in the range [1,12]
+    // avoid exception: org.joda.time.IllegalFieldValueException: Cannot parse "0000-00-00
+    // 00:00:00": Value 0 for monthOfYear must be in the range [1,12]
     if (TIMESTAMP_NULL_DEFAULT.equals(value)) {
       value = null;
     }

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/types/TimestampType.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/types/TimestampType.java
@@ -48,6 +48,11 @@ public class TimestampType extends AbstractDateTimeType {
 
   public static final MySQLType[] subTypes = new MySQLType[] {MySQLType.TypeTimestamp};
 
+  /**
+   * Default value for timestamp type is 0000-00-00 00:00:00
+   */
+  public static final String TIMESTAMP_NULL_DEFAULT = "0000-00-00 00:00:00";
+
   TimestampType(MySQLType tp) {
     super(tp);
   }
@@ -88,6 +93,15 @@ public class TimestampType extends AbstractDateTimeType {
   @Override
   protected Timestamp decodeNotNullForBatchWrite(int flag, CodecDataInput cdi) {
     return decodeDateTimeForBatchWrite(flag, cdi);
+  }
+
+  @Override
+  public Object getOriginDefaultValue(String value, long version) {
+    // avoid exception: org.joda.time.IllegalFieldValueException: Cannot parse "0000-00-00 00:00:00": Value 0 for monthOfYear must be in the range [1,12]
+    if (value != null && value.equals(TIMESTAMP_NULL_DEFAULT)) {
+      value = null;
+    }
+    return super.getOriginDefaultValue(value, version);
   }
 
   @Override

--- a/tidb/src/main/java/io/tidb/bigdata/tidb/types/TimestampType.java
+++ b/tidb/src/main/java/io/tidb/bigdata/tidb/types/TimestampType.java
@@ -98,7 +98,7 @@ public class TimestampType extends AbstractDateTimeType {
   @Override
   public Object getOriginDefaultValue(String value, long version) {
     // avoid exception: org.joda.time.IllegalFieldValueException: Cannot parse "0000-00-00 00:00:00": Value 0 for monthOfYear must be in the range [1,12]
-    if (value != null && value.equals(TIMESTAMP_NULL_DEFAULT)) {
+    if (TIMESTAMP_NULL_DEFAULT.equals(value)) {
       value = null;
     }
     return super.getOriginDefaultValue(value, version);

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
@@ -1,0 +1,26 @@
+package io.tidb.bigdata.tidb.meta;
+
+import io.tidb.bigdata.tidb.types.TimestampType;
+import org.junit.Test;
+
+public class TiColumnInfoTest {
+
+  @Test
+  public void testToProto() {
+    TiColumnInfo columnInfo =
+        new TiColumnInfo(
+            1L,
+            "name",
+            0,
+            TimestampType.TIMESTAMP,
+            SchemaState.StatePublic,
+            "0000-00-00 00:00:00",
+            "0000-00-00 00:00:00",
+            "0000-00-00 00:00:00",
+            "timestamp",
+            1,
+            "",
+            false);
+    System.out.println(columnInfo.getOriginDefaultValueAsByteString());
+  }
+}

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
@@ -39,7 +39,6 @@ public class TiColumnInfoTest {
             1,
             "",
             false);
-    assertEquals(
-        "\000", columnInfo.getOriginDefaultValueAsByteString().toStringUtf8());
+    assertEquals("\000", columnInfo.getOriginDefaultValueAsByteString().toStringUtf8());
   }
 }

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
@@ -1,5 +1,7 @@
 package io.tidb.bigdata.tidb.meta;
 
+import static org.junit.Assert.assertEquals;
+
 import io.tidb.bigdata.tidb.types.TimestampType;
 import org.junit.Test;
 
@@ -15,12 +17,13 @@ public class TiColumnInfoTest {
             TimestampType.TIMESTAMP,
             SchemaState.StatePublic,
             "0000-00-00 00:00:00",
-            "0000-00-00 00:00:00",
+            "2024-04-01 00:00:00",
             "0000-00-00 00:00:00",
             "timestamp",
             1,
             "",
             false);
-    System.out.println(columnInfo.getOriginDefaultValueAsByteString());
+    assertEquals(
+        "\000", columnInfo.getOriginDefaultValueAsByteString().toStringUtf8());
   }
 }

--- a/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
+++ b/tidb/src/test/java/io/tidb/bigdata/tidb/meta/TiColumnInfoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 TiDB Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.tidb.bigdata.tidb.meta;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
…ps://github.com/tidb-incubator/TiBigData/issues/269

## What is the purpose of the change

issue: https://github.com/tidb-incubator/TiBigData/issues/269
avoid exception Cannot parse "0000-00-00 00:00:00": Value 0 for monthOfYear must be in the range [1,12]

## Brief change log

*(for example:)*
- *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
- *Deployments RPC transmits only the blob storage reference*
- *TaskManagers retrieve the TaskInfo from the blob cache*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency):  no)
- The public API: (no)
- The runtime per-record code paths (performance sensitive): (yes)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
